### PR TITLE
Add ability for primary linked data to be updated when associated data is changing

### DIFF
--- a/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
+++ b/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
@@ -1,0 +1,72 @@
+using Btms.Backend.Data.InMemory;
+using Btms.Business.Services.Linking;
+using Btms.Model.Auditing;
+using Btms.Model.Ipaffs;
+using FluentAssertions;
+using Xunit;
+
+namespace Btms.Business.Tests.Services.Linking;
+
+public class AssociatedDataServiceTests
+{
+    private string _existingId = nameof(_existingId);
+    
+    private readonly MemoryMongoDbContext _mongoDbContext = new();
+    
+    [Fact]
+    public async Task Update_ExistingNotification_NoAuditEntries_UpdatesAndAddsFirstAuditEntry()
+    {
+        var subject = await CreateSubject();
+        var existingNotification = await _mongoDbContext.Notifications.Find(x => x.Id == _existingId) ??
+                                   throw new InvalidOperationException();
+
+        await subject.Update([existingNotification], "audit-id", CancellationToken.None);
+
+        _mongoDbContext.Notifications.Should()
+            .ContainEquivalentOf(new
+            {
+                Id = _existingId,
+                AuditEntries = (object[])
+                [
+                    new { Id = "audit-id", Status = "AssociatedUpdate", CreatedBy = CreatedBySystem.Btms, Version = 1 }
+                ]
+            });
+    }
+    
+    [Fact]
+    public async Task Update_ExistingNotification_ExistingAuditEntries_UpdatesAndAddsSecondAuditEntry()
+    {
+        var subject = await CreateSubject(addFirstAuditEntry: true);
+        var existingNotification = await _mongoDbContext.Notifications.Find(x => x.Id == _existingId) ??
+                                   throw new InvalidOperationException();
+
+        await subject.Update([existingNotification], "audit-id", CancellationToken.None);
+
+        _mongoDbContext.Notifications.Should()
+            .ContainEquivalentOf(new
+            {
+                Id = _existingId,
+                AuditEntries = (object[])
+                [
+                    new { Id = "first-audit-id", Version = 1 },
+                    new { Id = "audit-id", Version = 2 }
+                ]
+            });
+    }
+
+    private async Task<AssociatedDataService> CreateSubject(bool addFirstAuditEntry = false)
+    {
+        var notification = new ImportNotification { Id = _existingId };
+        
+        if (addFirstAuditEntry)
+            notification.AuditEntries.Add(new AuditEntry
+            {
+                Id = "first-audit-id",
+                Version = 1
+            });
+        
+        await _mongoDbContext.Notifications.Insert(notification);
+        
+        return new AssociatedDataService(_mongoDbContext);
+    }
+}

--- a/Btms.Business/Extensions/ServiceCollectionExtensions.cs
+++ b/Btms.Business/Extensions/ServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddScoped<ILinkingService, LinkingService>();
+        services.AddScoped<IAssociatedDataService, AssociatedDataService>();
         services.AddScoped<IValidationService, ValidationService>();
         services.AddScoped<IDecisionService, DecisionService>();
         services.AddScoped<IMatchingService, MatchingService>();

--- a/Btms.Business/Services/Linking/AssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/AssociatedDataService.cs
@@ -1,0 +1,29 @@
+using Btms.Backend.Data;
+using Btms.Model.Auditing;
+using Btms.Model.Ipaffs;
+
+namespace Btms.Business.Services.Linking;
+
+public class AssociatedDataService(IMongoDbContext mongoDbContext) : IAssociatedDataService
+{
+    public async Task Update(
+        List<ImportNotification> notifications, 
+        string auditEntryId, 
+        CancellationToken cancellationToken)
+    {
+        foreach (var notification in notifications)
+        {
+            var auditEntry = AuditEntry.CreateAssociatedUpdate(
+                auditEntryId,
+                notification.AuditEntries.LastOrDefault()?.Version + 1 ?? 1);
+            
+            notification.Changed(auditEntry);
+            
+            // Assumes the list of notifications exists in the DB already
+            await mongoDbContext.Notifications.Update(
+                notification, 
+                notification._Etag, 
+                cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Btms.Business/Services/Linking/IAssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/IAssociatedDataService.cs
@@ -1,0 +1,8 @@
+using Btms.Model.Ipaffs;
+
+namespace Btms.Business.Services.Linking;
+
+public interface IAssociatedDataService
+{
+    Task Update(List<ImportNotification> notifications, string auditEntryId, CancellationToken cancellationToken);
+}

--- a/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
+++ b/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
@@ -1,4 +1,3 @@
-using Btms.Backend.Data;
 using Btms.Business.Builders;
 using Btms.Business.Pipelines.PreProcessing;
 using Btms.Business.Services.Decisions;
@@ -8,6 +7,7 @@ using Btms.Business.Services.Validating;
 using Btms.Consumers.Extensions;
 using Btms.Model;
 using Btms.Model.Auditing;
+using Btms.Model.Ipaffs;
 using Btms.Types.Alvs;
 using Btms.Types.Alvs.Mapping;
 using FluentAssertions;
@@ -21,6 +21,13 @@ namespace Btms.Consumers.Tests;
 
 public class ClearanceRequestConsumerTests
 {
+    private readonly ILinkingService _mockLinkingService = Substitute.For<ILinkingService>();
+    private readonly IDecisionService _decisionService = Substitute.For<IDecisionService>();
+    private readonly IMatchingService _matchingService = Substitute.For<IMatchingService>();
+    private readonly IValidationService _validationService = Substitute.For<IValidationService>();
+    private readonly IAssociatedDataService _associatedDataService = Substitute.For<IAssociatedDataService>();
+    private readonly IPreProcessor<AlvsClearanceRequest, Movement> _preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Movement>>();
+    
     [Theory]
     [InlineData(PreProcessingOutcome.New)]
     [InlineData(PreProcessingOutcome.Skipped)]
@@ -32,79 +39,34 @@ public class ClearanceRequestConsumerTests
         var clearanceRequest = CreateAlvsClearanceRequest();
         var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
         var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
-            
         mb.Update(AuditEntry.CreateLinked("Test", 1));
-
         var movement = mb.Build();
-
-        var mockLinkingService = Substitute.For<ILinkingService>();
-        var decisionService = Substitute.For<IDecisionService>();
-        var matchingService = Substitute.For<IMatchingService>();
-        var validationService = Substitute.For<IValidationService>();
-        var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
-        var mongoDbContext = Substitute.For<IMongoDbContext>();
-
-        preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
+        _preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(outcome, movement, null)));
-
-        var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
-                {
-                    Context = new ConsumerContext
-                    {
-                        Headers = new Dictionary<string, object>
-                        {
-                            { "messageId", clearanceRequest.Header!.EntryReference! }
-                        }
-                    }
-                };
+        var consumer = CreateSubject(clearanceRequest.Header!.EntryReference!);
 
         // ACT
         await consumer.OnHandle(clearanceRequest);
 
         // ASSERT
         consumer.Context.IsLinked().Should().BeFalse();
-
-        await mockLinkingService.DidNotReceive().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
+        await _mockLinkingService.DidNotReceive().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task WhenPreProcessingSucceeds_AndLastAuditEntryIsCreated_ThenLinkShouldBeRun()
     {
         // ARRANGE
-        var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
         var clearanceRequest = CreateAlvsClearanceRequest();
-        
+        var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
         var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
-            
         mb.Update(mb.CreateAuditEntry("Test",  CreatedBySystem.Cds));
-
         var movement = mb.Build();
-        
-        var mockLinkingService = Substitute.For<ILinkingService>();
-        var decisionService = Substitute.For<IDecisionService>();
-        var matchingService = Substitute.For<IMatchingService>();
-        var validationService = Substitute.For<IValidationService>();
-        var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
-        var mongoDbContext = Substitute.For<IMongoDbContext>();
-
-        mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)));
-
-        preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
+        _preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(PreProcessingOutcome.New, movement, null)));
-
-        var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
-                {
-                    Context = new ConsumerContext
-                    {
-                        Headers = new Dictionary<string, object>
-                        {
-                            { "messageId", clearanceRequest.Header!.EntryReference! }
-                        }
-                    }
-                };
+        _mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)));
+        var consumer = CreateSubject(clearanceRequest.Header!.EntryReference!);
 
         // ACT
         await consumer.OnHandle(clearanceRequest);
@@ -112,13 +74,57 @@ public class ClearanceRequestConsumerTests
         // ASSERT
         consumer.Context.IsPreProcessed().Should().BeTrue();
         consumer.Context.IsLinked().Should().BeTrue();
+        await _mockLinkingService.Received().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
+    }
 
-        await mockLinkingService.Received().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
+    [Fact]
+    public async Task WhenPreProcessingSucceeds_AndLinked_AndPostLinkValidated_ThenAssociatedDataUpdated()
+    {
+        // ARRANGE
+        var clearanceRequest = CreateAlvsClearanceRequest();
+        var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
+        var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
+        mb.Update(mb.CreateAuditEntry("Test",  CreatedBySystem.Cds));
+        var movement = mb.Build();
+        var notifications = new List<ImportNotification> { new() };
+        _preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
+            .Returns(Task.FromResult(new PreProcessingResult<Movement>(PreProcessingOutcome.New, movement, null)));
+        _mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)
+            {
+                Notifications = notifications
+            }));
+        _validationService.PostLinking(Arg.Any<LinkContext>(), Arg.Any<LinkResult>(), Arg.Any<Movement?>(),
+            Arg.Any<ImportNotification?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        var consumer = CreateSubject(clearanceRequest.Header!.EntryReference!);
+
+        // ACT
+        await consumer.OnHandle(clearanceRequest);
+
+        // ASSERT
+        await _associatedDataService.Received().Update(notifications, clearanceRequest.Header!.EntryReference!,
+            Arg.Any<CancellationToken>());
     }
 
     private static AlvsClearanceRequest CreateAlvsClearanceRequest()
     {
         return ClearanceRequestBuilder.Default()
             .WithValidDocumentReferenceNumbers().Build();
+    }
+
+    private AlvsClearanceRequestConsumer CreateSubject(string messageId)
+    {
+        return new AlvsClearanceRequestConsumer(_preProcessor, _mockLinkingService, _matchingService, _decisionService,
+            _validationService, _associatedDataService, NullLogger<AlvsClearanceRequestConsumer>.Instance)
+        {
+            Context = new ConsumerContext
+            {
+                Headers = new Dictionary<string, object>
+                {
+                    { "messageId", messageId }
+                }
+            }
+        };
     }
 }

--- a/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
+++ b/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
@@ -1,3 +1,4 @@
+using Btms.Backend.Data;
 using Btms.Business.Builders;
 using Btms.Business.Pipelines.PreProcessing;
 using Btms.Business.Services.Decisions;
@@ -41,12 +42,13 @@ public class ClearanceRequestConsumerTests
         var matchingService = Substitute.For<IMatchingService>();
         var validationService = Substitute.For<IValidationService>();
         var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
+        var mongoDbContext = Substitute.For<IMongoDbContext>();
 
         preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(outcome, movement, null)));
 
         var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance)
+                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
                 {
                     Context = new ConsumerContext
                     {
@@ -84,6 +86,7 @@ public class ClearanceRequestConsumerTests
         var matchingService = Substitute.For<IMatchingService>();
         var validationService = Substitute.For<IValidationService>();
         var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
+        var mongoDbContext = Substitute.For<IMongoDbContext>();
 
         mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)));
@@ -92,7 +95,7 @@ public class ClearanceRequestConsumerTests
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(PreProcessingOutcome.New, movement, null)));
 
         var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance)
+                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
                 {
                     Context = new ConsumerContext
                     {

--- a/Btms.Model/Auditing/AuditEntry.cs
+++ b/Btms.Model/Auditing/AuditEntry.cs
@@ -146,6 +146,21 @@ public class AuditEntry
             Status = "Linked"
         };
     }
+
+    public static AuditEntry CreateAssociatedUpdate(string id, int version)
+    {
+        var t = DateTime.UtcNow;
+        
+        return new AuditEntry
+        {
+            Id = id,
+            Version = version,
+            CreatedSource = t,
+            CreatedBy = CreatedBySystem.Btms,
+            CreatedLocal = t,
+            Status = "AssociatedUpdate"
+        };
+    }
     
     public static AuditEntry CreateUnlinked(string id, int version, DateTime? lastUpdated)
     {


### PR DESCRIPTION
Primarily for the benefit of the PHA API, we need to signal when primary linked data is changing. 

When a movement is linked to an import notification, the relationship is created between the two entities and saved, therefore triggering a change to the notification's `Updated` field.

Should a change to the movement be processed, it does not need to link as it's already linked and therefore on the movement is updated.

The PHA API queries import notifications that have changed within a period of time by looking at the notification's `Updated` field. If an associated movement is changed then currently the linked notification will not be updated. This PR changes that behaviour and it updates each linked notification if the movement is deemed to be changing too.

The logic for this has been kept within the Linking business space but included as a separate service.

The AssociatedDataService would also be used when GVMS data is handled by BTMS and linked to import notifications, although it's unclear at this stage if GVMS data will actually change once it has been created.

This PR proposes the changes for the BTMS team to review and critique.

A working assuming is that the `AssociatedDataService`'s `Update` method will only be called with import notifications that already exist.

~The BTMS integration tests have not been run yet either.~ They look to have run as part of the build, despite quite a few being SKIPPED.