### PR TITLE
Alternate relationship querying approach for review

### DIFF
--- a/Btms.Backend.Data/IMongoCollectionSet.cs
+++ b/Btms.Backend.Data/IMongoCollectionSet.cs
@@ -11,10 +11,10 @@ public interface IMongoCollectionSet<T> : IQueryable<T> where T : IDataEntity
     
     Task Insert(T item, IMongoDbTransaction transaction = default!, CancellationToken cancellationToken = default);
 
-    Task Update(T item, IMongoDbTransaction transaction = default!,
+    Task Update(T item, bool setUpdated = true, IMongoDbTransaction transaction = default!,
         CancellationToken cancellationToken = default);
     
-    Task Update(T item, string etag, IMongoDbTransaction transaction = default!,
+    Task Update(T item, string etag, bool setUpdated = true, IMongoDbTransaction transaction = default!,
         CancellationToken cancellationToken = default);
     
     IAggregateFluent<T> Aggregate();

--- a/Btms.Backend.Data/InMemory/MemoryCollectionSet.cs
+++ b/Btms.Backend.Data/InMemory/MemoryCollectionSet.cs
@@ -70,7 +70,9 @@ public class MemoryCollectionSet<T> : IMongoCollectionSet<T> where T : IDataEnti
         }
 
         item._Etag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
-        item.Updated = DateTime.UtcNow;
+        
+        if (setUpdated)
+            item.Updated = DateTime.UtcNow;
         
         _data[_data.IndexOf(existingItem)] = item;
         

--- a/Btms.Backend.Data/Mongo/MongoCollectionSet.cs
+++ b/Btms.Backend.Data/Mongo/MongoCollectionSet.cs
@@ -43,8 +43,7 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
     public Task Insert(T item, IMongoDbTransaction? transaction, CancellationToken cancellationToken = default)
     {
         item._Etag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
-        item.Created = DateTime.UtcNow;
-        item.Updated = DateTime.UtcNow;
+        item.Created = item.Updated = dbContext.TimeProvider.GetUtcNow().UtcDateTime;
         
         var session = transaction is null ? dbContext.ActiveTransaction?.Session : transaction.Session;
         
@@ -68,7 +67,7 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
         item._Etag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
         
         if (setUpdated)
-            item.Updated = DateTime.UtcNow;
+            item.Updated = dbContext.TimeProvider.GetUtcNow().UtcDateTime;
         
         var session = transaction is null ? dbContext.ActiveTransaction?.Session : transaction.Session;
         var updateResult = session is not null

--- a/Btms.Backend.Data/Mongo/MongoCollectionSet.cs
+++ b/Btms.Backend.Data/Mongo/MongoCollectionSet.cs
@@ -4,19 +4,18 @@ using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 using System.Collections;
 using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore;
 
 namespace Btms.Backend.Data.Mongo;
 
 public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionName = null!)
     : IMongoCollectionSet<T> where T : IDataEntity
 {
-    private readonly IMongoCollection<T> collection = string.IsNullOrEmpty(collectionName)
+    private readonly IMongoCollection<T> _collection = string.IsNullOrEmpty(collectionName)
         ? dbContext.Database.GetCollection<T>(typeof(T).Name)
         : dbContext.Database.GetCollection<T>(collectionName);
 
-    private IMongoQueryable<T> EntityQueryable => collection.AsQueryable();
-        
+    private IMongoQueryable<T> EntityQueryable => _collection.AsQueryable();
+    
     public IEnumerator<T> GetEnumerator()
     {
         return EntityQueryable.GetEnumerator();
@@ -46,34 +45,34 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
         item._Etag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
         item.Created = DateTime.UtcNow;
         item.Updated = DateTime.UtcNow;
+        
         var session = transaction is null ? dbContext.ActiveTransaction?.Session : transaction.Session;
+        
         return session is not null
-            ? collection.InsertOneAsync(session, item, cancellationToken: cancellationToken)
-            : collection.InsertOneAsync(item, cancellationToken: cancellationToken);
+            ? _collection.InsertOneAsync(session, item, cancellationToken: cancellationToken)
+            : _collection.InsertOneAsync(item, cancellationToken: cancellationToken);
     }
 
-    public async Task Update(T item, IMongoDbTransaction? transaction = null,
+    public async Task Update(T item, bool setUpdated = true, IMongoDbTransaction? transaction = null,
         CancellationToken cancellationToken = default)
     {
-        await Update(item, item._Etag, transaction, cancellationToken);
+        await Update(item, item._Etag, setUpdated, transaction, cancellationToken);
     }
 
-    public async Task Update(T item, string etag, IMongoDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+    public async Task Update(T item, string etag, bool setUpdated = true, IMongoDbTransaction? transaction = null, CancellationToken cancellationToken = default)
     {
-        // etag = etag ?? 
-        
         ArgumentNullException.ThrowIfNull(etag);
         var builder = Builders<T>.Filter;
-
         var filter = builder.Eq(x => x.Id, item.Id) & builder.Eq(x => x._Etag, etag);
 
         item._Etag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
         item.Updated = DateTime.UtcNow;
+        
         var session = transaction is null ? dbContext.ActiveTransaction?.Session : transaction.Session;
         var updateResult = session is not null
-            ? await collection.ReplaceOneAsync(session, filter, item,
+            ? await _collection.ReplaceOneAsync(session, filter, item,
                 cancellationToken: cancellationToken)
-            : await collection.ReplaceOneAsync(filter, item,
+            : await _collection.ReplaceOneAsync(filter, item,
                 cancellationToken: cancellationToken);
 
         if (updateResult.ModifiedCount == 0)
@@ -84,6 +83,6 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
 
     public IAggregateFluent<T> Aggregate()
     {
-        return collection.Aggregate();
+        return _collection.Aggregate();
     }
 }

--- a/Btms.Backend.Data/Mongo/MongoCollectionSet.cs
+++ b/Btms.Backend.Data/Mongo/MongoCollectionSet.cs
@@ -66,7 +66,9 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
         var filter = builder.Eq(x => x.Id, item.Id) & builder.Eq(x => x._Etag, etag);
 
         item._Etag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
-        item.Updated = DateTime.UtcNow;
+        
+        if (setUpdated)
+            item.Updated = DateTime.UtcNow;
         
         var session = transaction is null ? dbContext.ActiveTransaction?.Session : transaction.Session;
         var updateResult = session is not null

--- a/Btms.Backend.Data/Mongo/MongoDbContext.cs
+++ b/Btms.Backend.Data/Mongo/MongoDbContext.cs
@@ -6,9 +6,10 @@ using MongoDB.Driver;
 
 namespace Btms.Backend.Data.Mongo;
 
-public class MongoDbContext(IMongoDatabase database, ILoggerFactory loggerFactory) : IMongoDbContext
+public class MongoDbContext(IMongoDatabase database, TimeProvider timeProvider, ILoggerFactory loggerFactory) : IMongoDbContext
 {
     internal IMongoDatabase Database { get; } = database;
+    internal TimeProvider TimeProvider { get; } = timeProvider;
     internal MongoDbTransaction? ActiveTransaction { get; private set; }
 
 

--- a/Btms.Backend.IntegrationTests/BaseApiTests.cs
+++ b/Btms.Backend.IntegrationTests/BaseApiTests.cs
@@ -1,14 +1,4 @@
-using System.Net;
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Btms.Backend.IntegrationTests.Helpers;
-using Btms.Business.Commands;
-using Btms.SyncJob;
-using FluentAssertions;
-using idunno.Authentication.Basic;
 using Microsoft.AspNetCore.Mvc.Testing;
 using TestGenerator.IntegrationTesting.Backend.Fixtures;
 using Xunit;
@@ -19,22 +9,19 @@ namespace Btms.Backend.IntegrationTests;
 
 public abstract class BaseApiTests
 {
-    protected readonly BtmsClient Client;
-    internal readonly IIntegrationTestsApplicationFactory Factory;
-    // protected readonly IntegrationTestsApplicationFactory Factory;
+    protected BtmsClient Client { get; }
+    protected IIntegrationTestsApplicationFactory Factory { get; }
     
     protected async Task ClearDb()
     {
         await Client.ClearDb();
     }
+    
     protected BaseApiTests(IIntegrationTestsApplicationFactory factory, ITestOutputHelper testOutputHelper, string databaseName = "SmokeTests")
     {
         Factory = factory;
         Factory.TestOutputHelper = testOutputHelper;
         Factory.DatabaseName = databaseName;
-        Client =
-            Factory.CreateBtmsClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
-        
+        Client = Factory.CreateBtmsClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
     }
-
 }

--- a/Btms.Backend.IntegrationTests/Data/MongoDbTests.cs
+++ b/Btms.Backend.IntegrationTests/Data/MongoDbTests.cs
@@ -1,0 +1,63 @@
+using Btms.Backend.IntegrationTests.Helpers;
+using Btms.Model.Ipaffs;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Btms.Backend.IntegrationTests.Data;
+
+[Trait("Category", "Integration")]
+public class MongoDbTests(ApplicationFactory factory, ITestOutputHelper testOutputHelper)
+    : BaseApiTests(factory, testOutputHelper), IClassFixture<ApplicationFactory>
+{
+    private readonly ImportNotification _notification = new() { ReferenceNumber = "CHEDA.GB.2025.1111111" };
+    
+    [Fact]
+    public async Task Insert_ShouldSetCreatedAndUpdated()
+    {
+        await ClearDb();
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        SetUtcNow(now);
+        
+        await Factory.GetDbContext().Notifications.Insert(_notification);
+
+        _notification.Created.Should().Be(now);
+        _notification.Updated.Should().Be(now);
+    }
+    
+    [Fact]
+    public async Task Update_ShouldSetUpdated()
+    {
+        await ClearDb();
+        var then = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        SetUtcNow(then);
+        await Factory.GetDbContext().Notifications.Insert(_notification);
+        var now = then.AddDays(1);
+        SetUtcNow(now);
+        
+        await Factory.GetDbContext().Notifications.Update(_notification);
+
+        _notification.Created.Should().Be(then);
+        _notification.Updated.Should().Be(now);
+    }
+    
+    [Fact]
+    public async Task Update_WhenSetUpdatedFalse_ShouldNotSetUpdated()
+    {
+        await ClearDb();
+        var then = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        SetUtcNow(then);
+        await Factory.GetDbContext().Notifications.Insert(_notification);
+        var now = then.AddDays(1);
+        SetUtcNow(now);
+        
+        await Factory.GetDbContext().Notifications.Update(_notification, setUpdated: false);
+
+        _notification.Created.Should().Be(then);
+        _notification.Updated.Should().Be(then);
+    }
+
+    private void SetUtcNow(DateTime dateTime) =>
+        ((FrozenTimeProvider)Factory.Services.GetRequiredService<TimeProvider>()).SetUtcNow(dateTime);
+}

--- a/Btms.Backend.IntegrationTests/FilterTests.cs
+++ b/Btms.Backend.IntegrationTests/FilterTests.cs
@@ -2,6 +2,7 @@ using Btms.Backend.IntegrationTests.Helpers;
 using Btms.Model.Ipaffs;
 using Btms.Model.Relationships;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,17 +18,17 @@ public class FilterTests(ApplicationFactory factory, ITestOutputHelper testOutpu
     [InlineData("2025-01-28T10:53:00,Y", "Expected DateTime, but was 'Y'")]
     [InlineData("2025-01-28T10:53:00,2025-01-28T11:53:00", "Expected from date as UTC, but was '2025-01-28T10:53:00.0000000'")]
     [InlineData("2025-01-28T10:53:00Z,2025-01-28T11:53:00", "Expected to date as UTC, but was '2025-01-28T11:53:00.0000000'")]
-    public void CustomFilter_RelationshipUpdated_Invalid_ShouldReturnError(string parameterValue, string expectedDetail)
+    public void CustomFilter_Updated_Invalid_ShouldReturnError(string parameterValue, string expectedDetail)
     {
         var document = Client.AsJsonApiClient()
-            .Get($"api/import-notifications?relationshipUpdated={parameterValue}", assertStatusCode: false);
+            .Get($"api/import-notifications?updated={parameterValue}", assertStatusCode: false);
 
         document.Errors.Should().ContainEquivalentOf(new
         {
             Status = "400",
-            Title = "Invalid 'relationshipUpdated' query value",
+            Title = "Invalid 'updated' query value",
             Detail = expectedDetail,
-            Source = new { Parameter = "relationshipUpdated" }
+            Source = new { Parameter = "updated" }
         });
     }
 
@@ -37,30 +38,37 @@ public class FilterTests(ApplicationFactory factory, ITestOutputHelper testOutpu
     [InlineData(14, 59, 59, true)]  // less than upper bound
     [InlineData(13, 59, 59, false)] // less than lower bound
     [InlineData(15, 0, 0, false)]   // equal to upper bound
-    public async Task CustomFilter_RelationshipUpdated_Valid_ShouldReturnNotifications(int hour, int minute, int second, bool expectSingleNotification)
+    public async Task CustomFilter_Updated_Valid_ShouldReturnNotifications(int hour, int minute, int second, bool expectNotifications)
     {
+        // The intent of this test is to seed one notification with an Updated property value
+        // outside the date range that is being queried, but that has a relationship Updated
+        // property value within the date range. Then have another notification with
+        // an Updated property value within the date range and no relationships. This will
+        // then prove our expected behaviour of:
+        //
+        //  notification.Updated in range OR any relationship.Updated in range
+        //
         await ClearDb();
-        var notification = new ImportNotification
-        {
-            Updated = new DateTime(2025, 1, 28, 12, 0, 0, DateTimeKind.Utc), _MatchReference = "123.456.789"
-        };
+        var updated = new DateTime(2025, 1, 28, hour, minute, second, DateTimeKind.Utc);
+        var notification = new ImportNotification { ReferenceNumber = "CHEDA.GB.2025.1111111" };
         notification.AddRelationship(new TdmRelationshipObject
         {
             Data =
             [
-                new RelationshipDataItem
-                {
-                    Type = "movements",
-                    Id = "123456788",
-                    Updated = new DateTime(2025, 1, 28, hour, minute, second, DateTimeKind.Utc)
-                }
+                new RelationshipDataItem { Type = "movements", Id = "123456788", Updated = updated }
             ]
         });
+        var timeProvider = (FrozenTimeProvider) Factory.Services.GetRequiredService<TimeProvider>();
+        // Freeze time so Insert call will use value
+        timeProvider.SetUtcNow(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         await Factory.GetDbContext().Notifications.Insert(notification);
+        var notification2 = new ImportNotification { ReferenceNumber = "CHEDA.GB.2025.2222222" };
+        timeProvider.SetUtcNow(updated);
+        await Factory.GetDbContext().Notifications.Insert(notification2);
 
         var document = Client.AsJsonApiClient()
-            .Get("api/import-notifications?relationshipUpdated=2025-01-28T14:00:00Z,2025-01-28T15:00:00Z");
+            .Get("api/import-notifications?updated=2025-01-28T14:00:00Z,2025-01-28T15:00:00Z");
 
-        document.Data.Count.Should().Be(expectSingleNotification ? 1 : 0);
+        document.Data.Count.Should().Be(expectNotifications ? 2 : 0);
     }
 }

--- a/Btms.Backend.IntegrationTests/FilterTests.cs
+++ b/Btms.Backend.IntegrationTests/FilterTests.cs
@@ -1,0 +1,66 @@
+using Btms.Backend.IntegrationTests.Helpers;
+using Btms.Model.Ipaffs;
+using Btms.Model.Relationships;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Btms.Backend.IntegrationTests;
+
+[Trait("Category", "Integration")]
+public class FilterTests(ApplicationFactory factory, ITestOutputHelper testOutputHelper)
+    : BaseApiTests(factory, testOutputHelper), IClassFixture<ApplicationFactory>
+{
+    [Theory]
+    [InlineData("X", "Expected format is two UTC dates separated by a comma, but was 'X'")]
+    [InlineData("X,Y", "Expected DateTime, but was 'X'")]
+    [InlineData("2025-01-28T10:53:00,Y", "Expected DateTime, but was 'Y'")]
+    [InlineData("2025-01-28T10:53:00,2025-01-28T11:53:00", "Expected from date as UTC, but was '2025-01-28T10:53:00.0000000'")]
+    [InlineData("2025-01-28T10:53:00Z,2025-01-28T11:53:00", "Expected to date as UTC, but was '2025-01-28T11:53:00.0000000'")]
+    public void CustomFilter_RelationshipUpdated_Invalid_ShouldReturnError(string parameterValue, string expectedDetail)
+    {
+        var document = Client.AsJsonApiClient()
+            .Get($"api/import-notifications?relationshipUpdated={parameterValue}", assertStatusCode: false);
+
+        document.Errors.Should().ContainEquivalentOf(new
+        {
+            Status = "400",
+            Title = "Invalid 'relationshipUpdated' query value",
+            Detail = expectedDetail,
+            Source = new { Parameter = "relationshipUpdated" }
+        });
+    }
+
+    [Theory]
+    [InlineData(14, 0, 0, true)]    // equal to lower bound
+    [InlineData(14, 0, 1, true)]    // greater than lower bound
+    [InlineData(14, 59, 59, true)]  // less than upper bound
+    [InlineData(13, 59, 59, false)] // less than lower bound
+    [InlineData(15, 0, 0, false)]   // equal to upper bound
+    public async Task CustomFilter_RelationshipUpdated_Valid_ShouldReturnNotifications(int hour, int minute, int second, bool expectSingleNotification)
+    {
+        await ClearDb();
+        var notification = new ImportNotification
+        {
+            Updated = new DateTime(2025, 1, 28, 12, 0, 0, DateTimeKind.Utc), _MatchReference = "123.456.789"
+        };
+        notification.AddRelationship(new TdmRelationshipObject
+        {
+            Data =
+            [
+                new RelationshipDataItem
+                {
+                    Type = "movements",
+                    Id = "123456788",
+                    Updated = new DateTime(2025, 1, 28, hour, minute, second, DateTimeKind.Utc)
+                }
+            ]
+        });
+        await Factory.GetDbContext().Notifications.Insert(notification);
+
+        var document = Client.AsJsonApiClient()
+            .Get("api/import-notifications?relationshipUpdated=2025-01-28T14:00:00Z,2025-01-28T15:00:00Z");
+
+        document.Data.Count.Should().Be(expectSingleNotification ? 1 : 0);
+    }
+}

--- a/Btms.Backend.IntegrationTests/Helpers/ApplicationFactory.cs
+++ b/Btms.Backend.IntegrationTests/Helpers/ApplicationFactory.cs
@@ -18,15 +18,13 @@ public interface IIntegrationTestsApplicationFactory
 {
     ITestOutputHelper TestOutputHelper { get; set; }
     string DatabaseName { get; set; }
-
     BtmsClient CreateBtmsClient(WebApplicationFactoryClientOptions options);
     IMongoDbContext GetDbContext();
+    IServiceProvider Services { get; }
 }
 
 public class ApplicationFactory : WebApplicationFactory<Program>, IIntegrationTestsApplicationFactory
 {
-    public DateTimeOffset TimeProviderStartDateTime { get; set; } = new(2025, 1, 28, 11, 30, 00, TimeSpan.Zero);
-    
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         // Any integration test overrides could be added here
@@ -81,6 +79,8 @@ public class ApplicationFactory : WebApplicationFactory<Program>, IIntegrationTe
     public ITestOutputHelper TestOutputHelper { get; set; } = null!;
 
     public string DatabaseName { get; set; } = null!;
+    
+    public DateTimeOffset TimeProviderStartDateTime { get; set; } = new(2025, 1, 28, 11, 30, 00, TimeSpan.Zero);
 
     public BtmsClient CreateBtmsClient(WebApplicationFactoryClientOptions options)
     {

--- a/Btms.Backend.IntegrationTests/Helpers/FrozenTimeProvider.cs
+++ b/Btms.Backend.IntegrationTests/Helpers/FrozenTimeProvider.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+
+namespace Btms.Backend.IntegrationTests.Helpers;
+
+public sealed class FrozenTimeProvider(DateTimeOffset startDateTime, TimeZoneInfo? localTimeZone = null) : TimeProvider
+{
+    private readonly DateTimeOffset _startDateTime = startDateTime;
+    private DateTimeOffset _dateTime = startDateTime;
+
+    public override TimeZoneInfo LocalTimeZone => localTimeZone ?? throw new NotSupportedException();
+    public override long TimestampFrequency => throw new NotSupportedException();
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        return _dateTime;
+    }
+
+    public void SetUtcNow(DateTimeOffset value)
+    {
+        _dateTime = value;
+    }
+
+    public void Reset()
+    {
+        _dateTime = _startDateTime;
+    }
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override long GetTimestamp()
+    {
+        throw new NotSupportedException();
+    }
+
+    public override string ToString()
+    {
+        return _dateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
+    }
+}

--- a/Btms.Backend.IntegrationTests/Helpers/FrozenTimeProvider.cs
+++ b/Btms.Backend.IntegrationTests/Helpers/FrozenTimeProvider.cs
@@ -25,16 +25,6 @@ public sealed class FrozenTimeProvider(DateTimeOffset startDateTime, TimeZoneInf
         _dateTime = _startDateTime;
     }
 
-    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
-    {
-        throw new NotSupportedException();
-    }
-
-    public override long GetTimestamp()
-    {
-        throw new NotSupportedException();
-    }
-
     public override string ToString()
     {
         return _dateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);

--- a/Btms.Backend/JsonApi/ImportNotificationJsonApiResourceDefinition.cs
+++ b/Btms.Backend/JsonApi/ImportNotificationJsonApiResourceDefinition.cs
@@ -1,0 +1,63 @@
+using Btms.Model.Ipaffs;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Errors;
+using JsonApiDotNetCore.Resources;
+using Microsoft.Extensions.Primitives;
+
+namespace Btms.Backend.JsonApi;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public class ImportNotificationJsonApiResourceDefinition(IResourceGraph resourceGraph)
+    : JsonApiResourceDefinition<ImportNotification, string?>(resourceGraph)
+{
+    private const string RelationshipUpdated = "relationshipUpdated";
+    private const string GenericError = $"Invalid '{RelationshipUpdated}' query value";
+
+    public override QueryStringParameterHandlers<ImportNotification>
+        OnRegisterQueryableHandlersForQueryStringParameters() =>
+        new() { [RelationshipUpdated] = HandleRelationshipUpdated, };
+
+    private static IQueryable<ImportNotification> HandleRelationshipUpdated(IQueryable<ImportNotification> source, StringValues parameterValue)
+    {
+        // The existence of a parameterValue will be validated by JsonApiDotNetCore
+        // before we hit our own validation logic
+        var value = parameterValue.ToString();
+        
+        var range = value.Split(",");
+        if (range.Length != 2)
+            throw new InvalidQueryStringParameterException(RelationshipUpdated,
+                GenericError,
+                $"Expected format is two UTC dates separated by a comma, but was '{value}'");
+
+        var from = ParseDateTime(range[0]);
+        var to = ParseDateTime(range[1]);
+        
+        EnsureUtc(nameof(from), from);
+        EnsureUtc(nameof(to), to);
+
+        return source.Where(x => x.Relationships.Movements.Data.Any(y => y.Updated >= from && y.Updated < to));
+    }
+
+    private static DateTime ParseDateTime(string value)
+    {
+        try
+        {
+            return (DateTime) RuntimeTypeConverter.ConvertType(value, typeof(DateTime))!;
+        }
+        catch (FormatException formatException)
+        {
+            throw new InvalidQueryStringParameterException(RelationshipUpdated,
+                GenericError,
+                $"Expected DateTime, but was '{value}'", 
+                formatException);
+        }
+    }
+
+    private static void EnsureUtc(string type, DateTime value)
+    {
+        if (value.Kind != DateTimeKind.Utc)
+            throw new InvalidQueryStringParameterException(RelationshipUpdated,
+                GenericError,
+                $"Expected {type} date as UTC, but was '{value:O}'");
+    }
+}

--- a/Btms.Backend/Program.cs
+++ b/Btms.Backend/Program.cs
@@ -142,6 +142,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
 		options.IncludeTotalResourceCount = true;
 		options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 		options.ClientIdGeneration = ClientIdGenerationMode.Allowed;
+        options.AllowUnknownQueryStringParameters = true;
 #if DEBUG
 		options.IncludeExceptionStackTraceInErrors = true;
 		options.IncludeRequestBodyInErrors = true;
@@ -151,6 +152,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
 
 	builder.Services.AddJsonApi(ConfigureJsonApiOptions,
 		discovery => discovery.AddAssembly(Assembly.Load("Btms.Model")));
+    builder.Services.AddResourceDefinition<ImportNotificationJsonApiResourceDefinition>();
 
 	builder.Services.AddJsonApiMongoDb();
 	builder.Services.AddScoped<IResponseModelAdapter, BtmsResponseModelAdapter>();

--- a/Btms.Business.Tests/Helpers/FrozenTimeProvider.cs
+++ b/Btms.Business.Tests/Helpers/FrozenTimeProvider.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+
+namespace Btms.Business.Tests.Helpers;
+
+public sealed class FrozenTimeProvider(DateTimeOffset startDateTime, TimeZoneInfo? localTimeZone = null) : TimeProvider
+{
+    private readonly DateTimeOffset _startDateTime = startDateTime;
+    private DateTimeOffset _dateTime = startDateTime;
+
+    public override TimeZoneInfo LocalTimeZone => localTimeZone ?? throw new NotSupportedException();
+    public override long TimestampFrequency => throw new NotSupportedException();
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        return _dateTime;
+    }
+
+    public void SetUtcNow(DateTimeOffset value)
+    {
+        _dateTime = value;
+    }
+
+    public void Reset()
+    {
+        _dateTime = _startDateTime;
+    }
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override long GetTimestamp()
+    {
+        throw new NotSupportedException();
+    }
+
+    public override string ToString()
+    {
+        return _dateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
+    }
+}

--- a/Btms.Business.Tests/Helpers/FrozenTimeProvider.cs
+++ b/Btms.Business.Tests/Helpers/FrozenTimeProvider.cs
@@ -25,16 +25,6 @@ public sealed class FrozenTimeProvider(DateTimeOffset startDateTime, TimeZoneInf
         _dateTime = _startDateTime;
     }
 
-    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
-    {
-        throw new NotSupportedException();
-    }
-
-    public override long GetTimestamp()
-    {
-        throw new NotSupportedException();
-    }
-
     public override string ToString()
     {
         return _dateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);

--- a/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
+++ b/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
@@ -1,0 +1,72 @@
+using Btms.Backend.Data.InMemory;
+using Btms.Business.Services.Linking;
+using Btms.Model.Auditing;
+using Btms.Model.Ipaffs;
+using FluentAssertions;
+using Xunit;
+
+namespace Btms.Business.Tests.Services.Linking;
+
+public class AssociatedDataServiceTests
+{
+    private string _existingId = nameof(_existingId);
+    
+    private readonly MemoryMongoDbContext _mongoDbContext = new();
+    
+    [Fact]
+    public async Task Update_ExistingNotification_NoAuditEntries_UpdatesAndAddsFirstAuditEntry()
+    {
+        var subject = await CreateSubject();
+        var existingNotification = await _mongoDbContext.Notifications.Find(x => x.Id == _existingId) ??
+                                   throw new InvalidOperationException();
+
+        await subject.Update([existingNotification], "audit-id", CancellationToken.None);
+
+        _mongoDbContext.Notifications.Should()
+            .ContainEquivalentOf(new
+            {
+                Id = _existingId,
+                AuditEntries = (object[])
+                [
+                    new { Id = "audit-id", Status = "AssociatedUpdate", CreatedBy = CreatedBySystem.Btms, Version = 1 }
+                ]
+            });
+    }
+    
+    [Fact]
+    public async Task Update_ExistingNotification_ExistingAuditEntries_UpdatesAndAddsSecondAuditEntry()
+    {
+        var subject = await CreateSubject(addFirstAuditEntry: true);
+        var existingNotification = await _mongoDbContext.Notifications.Find(x => x.Id == _existingId) ??
+                                   throw new InvalidOperationException();
+
+        await subject.Update([existingNotification], "audit-id", CancellationToken.None);
+
+        _mongoDbContext.Notifications.Should()
+            .ContainEquivalentOf(new
+            {
+                Id = _existingId,
+                AuditEntries = (object[])
+                [
+                    new { Id = "first-audit-id", Version = 1 },
+                    new { Id = "audit-id", Version = 2 }
+                ]
+            });
+    }
+
+    private async Task<AssociatedDataService> CreateSubject(bool addFirstAuditEntry = false)
+    {
+        var notification = new ImportNotification { Id = _existingId };
+        
+        if (addFirstAuditEntry)
+            notification.AuditEntries.Add(new AuditEntry
+            {
+                Id = "first-audit-id",
+                Version = 1
+            });
+        
+        await _mongoDbContext.Notifications.Insert(notification);
+        
+        return new AssociatedDataService(_mongoDbContext);
+    }
+}

--- a/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
+++ b/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
@@ -81,7 +81,7 @@ public class AssociatedDataServiceTests
 
         existingNotification._Etag.Should().NotBe(etag);
         existingNotification.Relationships.Movements.Data.Should().ContainSingle();
-        existingNotification.Relationships.Movements.Data[0].Updated.Should().Be(_timeProviderNow.DateTime);
+        existingNotification.Relationships.Movements.Data[0].Updated.Should().Be(_timeProviderNow.UtcDateTime);
     }
 
     private async Task<AssociatedDataService> CreateSubject(Movement? movement = null)

--- a/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
+++ b/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
@@ -87,7 +87,7 @@ public class AssociatedDataServiceTests
         }, CancellationToken.None);
 
         existingNotification._Etag.Should().NotBe(etag);
-        existingNotification.Updated.Should().BeAfter(updated);
+        existingNotification.Updated.Should().Be(updated);
         existingNotification.Relationships.Movements.Data.Should().ContainSingle();
         existingNotification.Relationships.Movements.Data[0].Updated.Should().Be(_timeProviderNow.UtcDateTime);
     }

--- a/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
+++ b/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
@@ -25,6 +25,7 @@ public class AssociatedDataServiceTests
         var existingNotification = await _mongoDbContext.Notifications.Find(x => x.Id == _existingId) ??
                                    throw new InvalidOperationException();
         var etag = existingNotification._Etag;
+        var updated = existingNotification.Updated;
         
         await subject.UpdateRelationships([existingNotification], new Movement
         {
@@ -32,6 +33,7 @@ public class AssociatedDataServiceTests
         }, CancellationToken.None);
 
         existingNotification._Etag.Should().Be(etag);
+        existingNotification.Updated.Should().Be(updated);
     }
 
     [Fact]
@@ -47,6 +49,7 @@ public class AssociatedDataServiceTests
         var existingNotification = await _mongoDbContext.Notifications.Find(x => x.Id == _existingId) ??
                                    throw new InvalidOperationException();
         var etag = existingNotification._Etag;
+        var updated = existingNotification.Updated;
         
         await subject.UpdateRelationships([existingNotification], new Movement
         {
@@ -55,6 +58,7 @@ public class AssociatedDataServiceTests
         }, CancellationToken.None);
 
         existingNotification._Etag.Should().Be(etag);
+        existingNotification.Updated.Should().Be(updated);
         existingNotification.Relationships.Movements.Data.Should().ContainSingle();
         existingNotification.Relationships.Movements.Data[0].Updated.Should().Be(_existingUpdated);
     }
@@ -74,6 +78,7 @@ public class AssociatedDataServiceTests
         var existingNotification = await _mongoDbContext.Notifications.Find(x => x.Id == _existingId) ??
                                    throw new InvalidOperationException();
         var etag = existingNotification._Etag;
+        var updated = existingNotification.Updated;
         
         await subject.UpdateRelationships([existingNotification], new Movement
         {
@@ -82,13 +87,14 @@ public class AssociatedDataServiceTests
         }, CancellationToken.None);
 
         existingNotification._Etag.Should().NotBe(etag);
+        existingNotification.Updated.Should().BeAfter(updated);
         existingNotification.Relationships.Movements.Data.Should().ContainSingle();
         existingNotification.Relationships.Movements.Data[0].Updated.Should().Be(_timeProviderNow.UtcDateTime);
     }
 
     private async Task<AssociatedDataService> CreateSubject(Movement? movement = null)
     {
-        var notification = new ImportNotification { Id = _existingId };
+        var notification = new ImportNotification { Id = _existingId, Updated = _existingUpdated };
 
         if (movement is not null)
             notification.AddRelationship(new TdmRelationshipObject

--- a/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
+++ b/Btms.Business.Tests/Services/Linking/AssociatedDataServiceTests.cs
@@ -59,12 +59,14 @@ public class AssociatedDataServiceTests
         existingNotification.Relationships.Movements.Data[0].Updated.Should().Be(_existingUpdated);
     }
 
-    [Fact]
-    public async Task UpdateRelationships_ExistingNotification_MatchingRelationships_ShouldUpdate()
+    [Theory]
+    [InlineData("123456789", "123456789")]
+    [InlineData("mrn", "MRN")]
+    public async Task UpdateRelationships_ExistingNotification_MatchingRelationships_ShouldUpdate(string existingId, string matchingId)
     {
         var movement = new Movement
         {
-            Id = "123456789",
+            Id = existingId,
             Updated = _existingUpdated,
             BtmsStatus = MovementStatus.Default()
         };
@@ -75,7 +77,7 @@ public class AssociatedDataServiceTests
         
         await subject.UpdateRelationships([existingNotification], new Movement
         {
-            Id = "123456789",
+            Id = matchingId,
             BtmsStatus = MovementStatus.Default()
         }, CancellationToken.None);
 

--- a/Btms.Business.Tests/Services/Linking/LinkingServiceTests.cs
+++ b/Btms.Business.Tests/Services/Linking/LinkingServiceTests.cs
@@ -1,4 +1,3 @@
-using Btms.Backend.Data;
 using Btms.Backend.Data.InMemory;
 using Btms.Business.Services.Linking;
 using Btms.Metrics;
@@ -16,9 +15,10 @@ namespace Btms.Business.Tests.Services.Linking;
 
 public class LinkingServiceTests
 {
-    private static readonly Random Random = new ();
-    protected readonly IMongoDbContext dbContext = new MemoryMongoDbContext();
-    private readonly LinkingMetrics linkingMetrics = new(new DummyMeterFactory());
+    private static readonly Random random = new();
+    private readonly MemoryMongoDbContext _dbContext = new();
+    private readonly LinkingMetrics _linkingMetrics = new(new DummyMeterFactory());
+    
     private static string GenerateDocumentReference(int id) => $"GBCVD2024.{id}";
     private static string GenerateNotificationReference(int id) => $"CHEDP.GB.2024.{id}";
 
@@ -26,7 +26,7 @@ public class LinkingServiceTests
     public async Task Link_UnknownContextType_ShouldThrowException()
     {
         // Arrange
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var ctx = new BadContext();
         
         // Act
@@ -42,9 +42,9 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(3, 1, 0);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
             
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContextWithDocuments(testData.Movements[0], [], [testData.Cheds[0], testData.Cheds[1]]);
         
         // Act
@@ -57,7 +57,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // added cheds
         beforeLinkChedRelCounts[0].Should().Be(0);
@@ -76,9 +76,9 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(3, 1, 0);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
             
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContextWithItems(testData.Movements[0], [], [testData.Cheds[0], testData.Cheds[1]]);
     
         // Act
@@ -91,7 +91,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // added cheds
         beforeLinkChedRelCounts[0].Should().Be(0);
@@ -109,13 +109,13 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData(3, 1, 0);
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         
         // establish existing links
         var movementCtx = CreateMovementContextWithDocuments(testData.Movements[0], [], [testData.Cheds[0]]);
         var prelink = await sut.Link(movementCtx);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // Act
         movementCtx = CreateMovementContextWithDocuments(prelink.Movements[0], [testData.Cheds[0]], [testData.Cheds[0], testData.Cheds[1]]);
@@ -128,7 +128,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // unchanged ched
         beforeLinkChedRelCounts[0].Should().Be(1);
@@ -148,13 +148,13 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData(3, 1, 0);
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         
         // establish existing links
         var movementCtx = CreateMovementContextWithItems(testData.Movements[0], [], [testData.Cheds[0]]);
         var prelink = await sut.Link(movementCtx);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // Act
         movementCtx = CreateMovementContextWithItems(prelink.Movements[0], [testData.Cheds[0]], [testData.Cheds[0], testData.Cheds[1]]);
@@ -167,7 +167,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // unchanged ched
         beforeLinkChedRelCounts[0].Should().Be(1);
@@ -187,13 +187,13 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData(3, 1, 0);
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         
         // establish existing links
         var movementCtx = CreateMovementContextWithDocuments(testData.Movements[0], [], [testData.Cheds[0]]);
         var prelink = await sut.Link(movementCtx);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // Act
         movementCtx = CreateMovementContextWithDocuments(prelink.Movements[0], [testData.Cheds[0]], [testData.Cheds[1]]);
@@ -206,7 +206,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // removed cheds
         beforeLinkChedRelCounts[0].Should().Be(1);
@@ -226,13 +226,13 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData(3, 1, 0);
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         
         // establish existing links
         var movementCtx = CreateMovementContextWithItems(testData.Movements[0], [], [testData.Cheds[0]]);
         var prelink = await sut.Link(movementCtx);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // Act
         movementCtx = CreateMovementContextWithItems(prelink.Movements[0], [testData.Cheds[0]], [testData.Cheds[1]]);
@@ -245,7 +245,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // removed cheds
         beforeLinkChedRelCounts[0].Should().Be(1);
@@ -265,7 +265,7 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData();
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContext(testData.Movements[0], [testData.Cheds[0], null], true, false);
 
         // Act
@@ -283,7 +283,7 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData();
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContext(testData.Movements[0], [null], true, false);
         
         // Act
@@ -301,13 +301,13 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData(4, 1, 0);
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         
         // establish existing links
         var movementCtx = CreateMovementContextWithDocuments(testData.Movements[0], [], [testData.Cheds[0], testData.Cheds[1], testData.Cheds[2]]);
         var prelink = await sut.Link(movementCtx);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // Act
         movementCtx = CreateMovementContextWithDocuments(prelink.Movements[0], [testData.Cheds[0], testData.Cheds[1], testData.Cheds[2]], [testData.Cheds[0]]);
@@ -320,7 +320,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // unchanged ched
         beforeLinkChedRelCounts[0].Should().Be(1);
@@ -342,13 +342,13 @@ public class LinkingServiceTests
     {
         // Arrange
         var testData = await AddTestData(4, 1, 0);
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         
         // establish existing links
         var movementCtx = CreateMovementContextWithItems(testData.Movements[0], [], [testData.Cheds[0], testData.Cheds[1], testData.Cheds[2]]);
         var prelink = await sut.Link(movementCtx);
         var beforeLinkChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // Act
         movementCtx = CreateMovementContextWithItems(prelink.Movements[0], [testData.Cheds[0], testData.Cheds[1], testData.Cheds[2]], [testData.Cheds[0]]);
@@ -361,7 +361,7 @@ public class LinkingServiceTests
         linkResult.Movements.Count.Should().Be(1);
         
         var afterChedRelCounts = testData.Cheds.Select(c =>
-            dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
+            _dbContext.Notifications.Single(x => x.Id == c.Id).Relationships.Movements.Data.Count).ToList();
         
         // unchanged ched
         beforeLinkChedRelCounts[0].Should().Be(1);
@@ -384,7 +384,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData();
         
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContext(testData.Movements[0], [testData.Cheds[0]], true, true);
         
         // Act
@@ -403,7 +403,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData();
         
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContext(null, [testData.Cheds[0]], true, false);
         
         // Act
@@ -422,7 +422,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(2, 1, 2);
 
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContext(null, [testData.Cheds[0], testData.Cheds[1]], false, true);
         
         // Act
@@ -439,7 +439,7 @@ public class LinkingServiceTests
     public async Task LinkMovement_NewRequest_NoMatchingCHEDs_NoMatchingTriggered()
     {
         // Arrange
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var movementCtx = CreateMovementContext(null, [null], true, false);
         
         // Act
@@ -458,7 +458,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData();
 
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var notificationCtx = CreateNotificationContext(testData.Cheds[0], true, true);
         
         // Act
@@ -477,7 +477,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(2,2,2);
         
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var notificationCtx = CreateNotificationContext(testData.Cheds[0], true, true);
         
         // Act
@@ -496,7 +496,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(1, 1, 0);
         
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var notificationCtx = CreateNotificationContext(testData.Cheds[0], true, true);
         
         // Act
@@ -515,7 +515,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(2, 2, 2);
         
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var notificationCtx = CreateNotificationContext(testData.Cheds[0], true, false);
         
         // Act
@@ -534,7 +534,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(0,4,0, 1);
         
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var notificationCtx = CreateNotificationContext(testData.UnmatchedChedRefs[0], string.Empty, false, true);
         
         // Act
@@ -553,7 +553,7 @@ public class LinkingServiceTests
         // Arrange
         var testData = await AddTestData(0,1,0, 1);
         
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var notificationCtx = CreateNotificationContext(testData.UnmatchedChedRefs[0], string.Empty, false, true);
         
         // Act
@@ -570,7 +570,7 @@ public class LinkingServiceTests
     public async Task LinkNotification_NewNotification_NoMatchingMRNs_NoMatchingTriggered()
     {
         // Arrange
-        var sut = new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        var sut = CreateLinkingService();
         var notificationCtx = CreateNotificationContext(null, false, false);
         
         // Act
@@ -585,7 +585,7 @@ public class LinkingServiceTests
 
     protected LinkingService CreateLinkingService()
     {
-        return new LinkingService(dbContext, linkingMetrics, NullLogger<LinkingService>.Instance);
+        return new LinkingService(_dbContext, _linkingMetrics, TimeProvider.System, NullLogger<LinkingService>.Instance);
     }
 
     protected MovementLinkContext CreateMovementContextWithItems(Movement? movement, List<ImportNotification?> existingCheds, List<ImportNotification?> receivedCheds)
@@ -785,7 +785,7 @@ public class LinkingServiceTests
             
             cheds.Add(ched);
             
-            await dbContext.Notifications.Insert(ched);
+            await _dbContext.Notifications.Insert(ched);
         }
 
         for (var i = 0; i < movementCount; i++)
@@ -835,7 +835,7 @@ public class LinkingServiceTests
                     });
             }
 
-            await dbContext.Movements.Insert(mov);
+            await _dbContext.Movements.Insert(mov);
         }
         
         return (cheds, movements, unmatchedChedRefs);
@@ -847,7 +847,7 @@ public class LinkingServiceTests
         
         for (var i = 0; i < 6; i++)
         {
-            intString += Random.Next(9).ToString();
+            intString += random.Next(9).ToString();
         }
         
         return int.Parse(intString);

--- a/Btms.Business/Extensions/ServiceCollectionExtensions.cs
+++ b/Btms.Business/Extensions/ServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddScoped<ILinkingService, LinkingService>();
+        services.AddScoped<IAssociatedDataService, AssociatedDataService>();
         services.AddScoped<IValidationService, ValidationService>();
         services.AddScoped<IDecisionService, DecisionService>();
         services.AddScoped<IMatchingService, MatchingService>();

--- a/Btms.Business/Services/Linking/AssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/AssociatedDataService.cs
@@ -25,6 +25,7 @@ public class AssociatedDataService(IMongoDbContext mongoDbContext, TimeProvider 
                 await mongoDbContext.Notifications.Update(
                     notification, 
                     notification._Etag, 
+                    setUpdated: false,
                     cancellationToken: cancellationToken);
             }
         }

--- a/Btms.Business/Services/Linking/AssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/AssociatedDataService.cs
@@ -11,8 +11,9 @@ public class AssociatedDataService(IMongoDbContext mongoDbContext, TimeProvider 
         foreach (var notification in notifications)
         {
             var changed = false;
-            
-            foreach (var relationship in notification.Relationships.Movements.Data.Where(x => x.Id == movement.Id))
+
+            foreach (var relationship in notification.Relationships.Movements.Data.Where(x =>
+                         string.Equals(x.Id, movement.Id, StringComparison.OrdinalIgnoreCase)))
             {
                 relationship.Updated = timeProvider.GetUtcNow().UtcDateTime;
                 changed = true;

--- a/Btms.Business/Services/Linking/AssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/AssociatedDataService.cs
@@ -14,7 +14,7 @@ public class AssociatedDataService(IMongoDbContext mongoDbContext, TimeProvider 
             
             foreach (var relationship in notification.Relationships.Movements.Data.Where(x => x.Id == movement.Id))
             {
-                relationship.Updated = timeProvider.GetUtcNow().DateTime;
+                relationship.Updated = timeProvider.GetUtcNow().UtcDateTime;
                 changed = true;
             }
 

--- a/Btms.Business/Services/Linking/AssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/AssociatedDataService.cs
@@ -1,0 +1,29 @@
+using Btms.Backend.Data;
+using Btms.Model.Auditing;
+using Btms.Model.Ipaffs;
+
+namespace Btms.Business.Services.Linking;
+
+public class AssociatedDataService(IMongoDbContext mongoDbContext) : IAssociatedDataService
+{
+    public async Task Update(
+        List<ImportNotification> notifications, 
+        string auditEntryId, 
+        CancellationToken cancellationToken)
+    {
+        foreach (var notification in notifications)
+        {
+            var auditEntry = AuditEntry.CreateAssociatedUpdate(
+                auditEntryId,
+                notification.AuditEntries.LastOrDefault()?.Version + 1 ?? 1);
+            
+            notification.Changed(auditEntry);
+            
+            // Assumes the list of notifications exists in the DB already
+            await mongoDbContext.Notifications.Update(
+                notification, 
+                notification._Etag, 
+                cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Btms.Business/Services/Linking/IAssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/IAssociatedDataService.cs
@@ -1,8 +1,9 @@
+using Btms.Model;
 using Btms.Model.Ipaffs;
 
 namespace Btms.Business.Services.Linking;
 
 public interface IAssociatedDataService
 {
-    Task Update(List<ImportNotification> notifications, string auditEntryId, CancellationToken cancellationToken);
+    Task UpdateRelationships(List<ImportNotification> notifications, Movement movement, CancellationToken cancellationToken);
 }

--- a/Btms.Business/Services/Linking/IAssociatedDataService.cs
+++ b/Btms.Business/Services/Linking/IAssociatedDataService.cs
@@ -1,0 +1,8 @@
+using Btms.Model.Ipaffs;
+
+namespace Btms.Business.Services.Linking;
+
+public interface IAssociatedDataService
+{
+    Task Update(List<ImportNotification> notifications, string auditEntryId, CancellationToken cancellationToken);
+}

--- a/Btms.Business/Services/Linking/LinkingService.cs
+++ b/Btms.Business/Services/Linking/LinkingService.cs
@@ -38,11 +38,15 @@ public static partial class LinkingServiceLogging
     internal static partial void LinkNotAttempted(this ILogger logger, string contextType, string matchIdentifier);
 }
 
-public class LinkingService(IMongoDbContext dbContext, LinkingMetrics metrics, ILogger<LinkingService> logger) : ILinkingService
+public class LinkingService(
+    IMongoDbContext dbContext, 
+    LinkingMetrics metrics, 
+    TimeProvider timeProvider, 
+    ILogger<LinkingService> logger) : ILinkingService
 {
     public async Task<LinkResult> Link(LinkContext linkContext, CancellationToken cancellationToken = default)
     {
-        var startedAt = TimeProvider.System.GetTimestamp();
+        var startedAt = timeProvider.GetTimestamp();
         LinkResult result;
         using (logger.BeginScope(new List<KeyValuePair<string, object>>
                {
@@ -135,7 +139,7 @@ public class LinkingService(IMongoDbContext dbContext, LinkingMetrics metrics, I
             }
             finally
             {
-                var e = TimeProvider.System.GetElapsedTime(startedAt);
+                var e = timeProvider.GetElapsedTime(startedAt);
                 metrics.Completed(e.TotalMilliseconds);
                 logger.LinkingFinished(linkContext.GetType().Name, linkContext.GetIdentifiers());
             }
@@ -146,7 +150,7 @@ public class LinkingService(IMongoDbContext dbContext, LinkingMetrics metrics, I
 
     public async Task UnLink(ImportNotificationLinkContext linkContext, CancellationToken cancellationToken = default)
     {
-        var startedAt = TimeProvider.System.GetTimestamp();
+        var startedAt = timeProvider.GetTimestamp();
         using (logger.BeginScope(new List<KeyValuePair<string, object>>
                {
                    new("MatchIdentifier", linkContext.GetIdentifiers()),
@@ -180,7 +184,7 @@ public class LinkingService(IMongoDbContext dbContext, LinkingMetrics metrics, I
             }
             finally
             {
-                var e = TimeProvider.System.GetElapsedTime(startedAt);
+                var e = timeProvider.GetElapsedTime(startedAt);
                 metrics.Completed(e.TotalMilliseconds);
                 logger.UnLinkingFinished(linkContext.GetType().Name, linkContext.GetIdentifiers());
             }

--- a/Btms.Business/Services/Linking/LinkingService.cs
+++ b/Btms.Business/Services/Linking/LinkingService.cs
@@ -105,7 +105,7 @@ public class LinkingService(IMongoDbContext dbContext, LinkingMetrics metrics, I
                             Data =
                             [
                                 RelationshipDataItem.CreateFromMovement(notification, movement,
-                                    notification._MatchReference)
+                                    notification._MatchReference, notification.Updated)
                             ]
                         });
 

--- a/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
+++ b/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
@@ -1,4 +1,3 @@
-using Btms.Backend.Data;
 using Btms.Business.Builders;
 using Btms.Business.Pipelines.PreProcessing;
 using Btms.Business.Services.Decisions;
@@ -8,6 +7,7 @@ using Btms.Business.Services.Validating;
 using Btms.Consumers.Extensions;
 using Btms.Model;
 using Btms.Model.Auditing;
+using Btms.Model.Ipaffs;
 using Btms.Types.Alvs;
 using Btms.Types.Alvs.Mapping;
 using FluentAssertions;
@@ -21,6 +21,13 @@ namespace Btms.Consumers.Tests;
 
 public class ClearanceRequestConsumerTests
 {
+    private readonly ILinkingService _mockLinkingService = Substitute.For<ILinkingService>();
+    private readonly IDecisionService _decisionService = Substitute.For<IDecisionService>();
+    private readonly IMatchingService _matchingService = Substitute.For<IMatchingService>();
+    private readonly IValidationService _validationService = Substitute.For<IValidationService>();
+    private readonly IAssociatedDataService _associatedDataService = Substitute.For<IAssociatedDataService>();
+    private readonly IPreProcessor<AlvsClearanceRequest, Movement> _preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Movement>>();
+    
     [Theory]
     [InlineData(PreProcessingOutcome.New)]
     [InlineData(PreProcessingOutcome.Skipped)]
@@ -32,79 +39,34 @@ public class ClearanceRequestConsumerTests
         var clearanceRequest = CreateAlvsClearanceRequest();
         var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
         var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
-            
         mb.Update(AuditEntry.CreateLinked("Test", 1));
-
         var movement = mb.Build();
-
-        var mockLinkingService = Substitute.For<ILinkingService>();
-        var decisionService = Substitute.For<IDecisionService>();
-        var matchingService = Substitute.For<IMatchingService>();
-        var validationService = Substitute.For<IValidationService>();
-        var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
-        var mongoDbContext = Substitute.For<IMongoDbContext>();
-
-        preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
+        _preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(outcome, movement, null)));
-
-        var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
-                {
-                    Context = new ConsumerContext
-                    {
-                        Headers = new Dictionary<string, object>
-                        {
-                            { "messageId", clearanceRequest.Header!.EntryReference! }
-                        }
-                    }
-                };
+        var consumer = CreateSubject(clearanceRequest.Header!.EntryReference!);
 
         // ACT
         await consumer.OnHandle(clearanceRequest);
 
         // ASSERT
         consumer.Context.IsLinked().Should().BeFalse();
-
-        await mockLinkingService.DidNotReceive().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
+        await _mockLinkingService.DidNotReceive().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task WhenPreProcessingSucceeds_AndLastAuditEntryIsCreated_ThenLinkShouldBeRun()
     {
         // ARRANGE
-        var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
         var clearanceRequest = CreateAlvsClearanceRequest();
-        
+        var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
         var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
-            
         mb.Update(mb.CreateAuditEntry("Test",  CreatedBySystem.Cds));
-
         var movement = mb.Build();
-        
-        var mockLinkingService = Substitute.For<ILinkingService>();
-        var decisionService = Substitute.For<IDecisionService>();
-        var matchingService = Substitute.For<IMatchingService>();
-        var validationService = Substitute.For<IValidationService>();
-        var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
-        var mongoDbContext = Substitute.For<IMongoDbContext>();
-
-        mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)));
-
-        preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
+        _preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(PreProcessingOutcome.New, movement, null)));
-
-        var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
-                {
-                    Context = new ConsumerContext
-                    {
-                        Headers = new Dictionary<string, object>
-                        {
-                            { "messageId", clearanceRequest.Header!.EntryReference! }
-                        }
-                    }
-                };
+        _mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)));
+        var consumer = CreateSubject(clearanceRequest.Header!.EntryReference!);
 
         // ACT
         await consumer.OnHandle(clearanceRequest);
@@ -112,13 +74,57 @@ public class ClearanceRequestConsumerTests
         // ASSERT
         consumer.Context.IsPreProcessed().Should().BeTrue();
         consumer.Context.IsLinked().Should().BeTrue();
+        await _mockLinkingService.Received().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
+    }
 
-        await mockLinkingService.Received().Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>());
+    [Fact]
+    public async Task WhenPreProcessingSucceeds_AndLinked_AndPostLinkValidated_ThenAssociatedDataUpdated()
+    {
+        // ARRANGE
+        var clearanceRequest = CreateAlvsClearanceRequest();
+        var mbFactory = new MovementBuilderFactory(NullLogger<MovementBuilder>.Instance);
+        var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
+        mb.Update(mb.CreateAuditEntry("Test",  CreatedBySystem.Cds));
+        var movement = mb.Build();
+        var notifications = new List<ImportNotification> { new() };
+        _preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
+            .Returns(Task.FromResult(new PreProcessingResult<Movement>(PreProcessingOutcome.New, movement, null)));
+        _mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)
+            {
+                Notifications = notifications
+            }));
+        _validationService.PostLinking(Arg.Any<LinkContext>(), Arg.Any<LinkResult>(), Arg.Any<Movement?>(),
+            Arg.Any<ImportNotification?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        var consumer = CreateSubject(clearanceRequest.Header!.EntryReference!);
+
+        // ACT
+        await consumer.OnHandle(clearanceRequest);
+
+        // ASSERT
+        await _associatedDataService.Received().Update(notifications, clearanceRequest.Header!.EntryReference!,
+            Arg.Any<CancellationToken>());
     }
 
     private static AlvsClearanceRequest CreateAlvsClearanceRequest()
     {
         return ClearanceRequestBuilder.Default()
             .WithValidDocumentReferenceNumbers().Build();
+    }
+
+    private AlvsClearanceRequestConsumer CreateSubject(string messageId)
+    {
+        return new AlvsClearanceRequestConsumer(_preProcessor, _mockLinkingService, _matchingService, _decisionService,
+            _validationService, _associatedDataService, NullLogger<AlvsClearanceRequestConsumer>.Instance)
+        {
+            Context = new ConsumerContext
+            {
+                Headers = new Dictionary<string, object>
+                {
+                    { "messageId", messageId }
+                }
+            }
+        };
     }
 }

--- a/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
+++ b/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
@@ -1,3 +1,4 @@
+using Btms.Backend.Data;
 using Btms.Business.Builders;
 using Btms.Business.Pipelines.PreProcessing;
 using Btms.Business.Services.Decisions;
@@ -41,12 +42,13 @@ public class ClearanceRequestConsumerTests
         var matchingService = Substitute.For<IMatchingService>();
         var validationService = Substitute.For<IValidationService>();
         var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
+        var mongoDbContext = Substitute.For<IMongoDbContext>();
 
         preProcessor.Process(Arg.Any<PreProcessingContext<AlvsClearanceRequest>>())
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(outcome, movement, null)));
 
         var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance)
+                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
                 {
                     Context = new ConsumerContext
                     {
@@ -84,6 +86,7 @@ public class ClearanceRequestConsumerTests
         var matchingService = Substitute.For<IMatchingService>();
         var validationService = Substitute.For<IValidationService>();
         var preProcessor = Substitute.For<IPreProcessor<AlvsClearanceRequest, Model.Movement>>();
+        var mongoDbContext = Substitute.For<IMongoDbContext>();
 
         mockLinkingService.Link(Arg.Any<LinkContext>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new LinkResult(LinkOutcome.Linked)));
@@ -92,7 +95,7 @@ public class ClearanceRequestConsumerTests
             .Returns(Task.FromResult(new PreProcessingResult<Movement>(PreProcessingOutcome.New, movement, null)));
 
         var consumer =
-                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance)
+                new AlvsClearanceRequestConsumer(preProcessor, mockLinkingService, matchingService, decisionService, validationService, NullLogger<AlvsClearanceRequestConsumer>.Instance, mongoDbContext)
                 {
                     Context = new ConsumerContext
                     {

--- a/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
+++ b/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
@@ -103,8 +103,7 @@ public class ClearanceRequestConsumerTests
         await consumer.OnHandle(clearanceRequest);
 
         // ASSERT
-        await _associatedDataService.Received().Update(notifications, clearanceRequest.Header!.EntryReference!,
-            Arg.Any<CancellationToken>());
+        await _associatedDataService.Received().UpdateRelationships(notifications, movement, Arg.Any<CancellationToken>());
     }
 
     private static AlvsClearanceRequest CreateAlvsClearanceRequest()

--- a/Btms.Consumers/AlvsClearanceRequestConsumer.cs
+++ b/Btms.Consumers/AlvsClearanceRequestConsumer.cs
@@ -63,8 +63,11 @@ namespace Btms.Consumers;
                 {
                     return;
                 }
-                
-                await associatedDataService.Update(linkResult.Notifications, messageId, Context.CancellationToken);
+
+                await associatedDataService.UpdateRelationships(
+                    linkResult.Notifications, 
+                    preProcessingResult.Record,
+                    Context.CancellationToken);
 
                 var matchResult = await matchingService.Process(
                     new MatchingContext(linkResult.Notifications, linkResult.Movements), Context.CancellationToken);

--- a/Btms.Model/Auditing/AuditEntry.cs
+++ b/Btms.Model/Auditing/AuditEntry.cs
@@ -147,6 +147,21 @@ public class AuditEntry
             Status = "Linked"
         };
     }
+
+    public static AuditEntry CreateAssociatedUpdate(string id, int version)
+    {
+        var t = DateTime.UtcNow;
+        
+        return new AuditEntry
+        {
+            Id = id,
+            Version = version,
+            CreatedSource = t,
+            CreatedBy = CreatedBySystem.Btms,
+            CreatedLocal = t,
+            Status = "AssociatedUpdate"
+        };
+    }
     
     public static AuditEntry CreateUnlinked(string id, int version, DateTime? lastUpdated)
     {

--- a/Btms.Model/Relationships/RelationshipDataItem.cs
+++ b/Btms.Model/Relationships/RelationshipDataItem.cs
@@ -15,6 +15,8 @@ public sealed class RelationshipDataItem
     [Attr] public int? SourceItem { get; set; }
 
     [Attr] public int? DestinationItem { get; set; }
+    
+    [Attr] public DateTime? Updated { get; set; }
 
     public int? MatchingLevel { get; set; }
 
@@ -42,6 +44,11 @@ public sealed class RelationshipDataItem
             meta.Add("self", Links.Self);
         }
 
+        if (Updated.HasValue)
+        {
+            meta.Add("updated", Updated.Value.ToString("O"));
+        }
+
         return meta;
     }
 
@@ -60,7 +67,7 @@ public sealed class RelationshipDataItem
         };
     }
 
-    public static RelationshipDataItem CreateFromMovement(ImportNotification notification, Movement movement, string matchReference)
+    public static RelationshipDataItem CreateFromMovement(ImportNotification notification, Movement movement, string matchReference, DateTime updated)
     {
         return new RelationshipDataItem
         {
@@ -71,7 +78,8 @@ public sealed class RelationshipDataItem
                 .Find(x => x.Documents!.ToList().Exists(d => d.DocumentReference!.Contains(matchReference)))
                 ?.ItemNumber,
             Links = new ResourceLink { Self = LinksBuilder.Movement.BuildRelatedMovementLink(movement.Id!) },
-            MatchingLevel = 1
+            MatchingLevel = 1,
+            Updated = updated
         };
     }
 }

--- a/TestGenerator.IntegrationTesting.Backend/Fixtures/BackendFixture.cs
+++ b/TestGenerator.IntegrationTesting.Backend/Fixtures/BackendFixture.cs
@@ -108,7 +108,7 @@ public class BackendFactory(string databaseName, ITestOutputHelper testOutputHel
                     
                     var db = client.GetDatabase($"btms-{dbName}");
                    
-                    mongoDbContext = new MongoDbContext(db, testOutputHelper.GetLoggerFactory());
+                    mongoDbContext = new MongoDbContext(db, TimeProvider.System, testOutputHelper.GetLoggerFactory());
                     return db;
                 });
 

--- a/TestGenerator.IntegrationTesting.Backend/JsonApiClient/JsonApiClient.cs
+++ b/TestGenerator.IntegrationTesting.Backend/JsonApiClient/JsonApiClient.cs
@@ -19,7 +19,8 @@ public class JsonApiClient(HttpClient client)
         string path,
         Dictionary<string, string>? query = null,
         Dictionary<string, string>? headers = null,
-        IList<string>? relations = null)
+        IList<string>? relations = null,
+        bool assertStatusCode = true)
     {
         client.DefaultRequestHeaders.Accept.Add(ContentType);
 
@@ -48,9 +49,9 @@ public class JsonApiClient(HttpClient client)
 
         var responseMessage = client.GetAsync(uri).Result;
 
-        responseMessage.StatusCode.Should().Be(HttpStatusCode.OK, $"Status code was {responseMessage.StatusCode}");
-
-
+        if (assertStatusCode)
+            responseMessage.StatusCode.Should().Be(HttpStatusCode.OK, $"Status code was {responseMessage.StatusCode}");
+        
         var s = responseMessage.Content.ReadAsStringAsync().Result;
 
         return JsonSerializer.Deserialize<ManyItemsJsonApiDocument>(s,


### PR DESCRIPTION
Originally proposed in PR https://github.com/DEFRA/btms-backend/pull/72, this PR is one of the alternative approaches that was discussed and favoured by those in the discussion.

A new `Updated` property on the relationship will be used and tracked when a related item is changing. 

Primarily for the benefit of the PHA API, we need to signal when primary linked data is changing. 

When a movement is linked to an import notification, the relationship is created between the two entities and saved, therefore triggering a change to the notification's `Updated` field.

Should a change to the movement be processed, it does not need to link as it's already linked and therefore only the movement is updated.

The PHA API queries import notifications that have changed within a period of time by looking at the notification's `Updated` field. If an associated movement is changed then currently the linked notification will not be updated. This PR changes that behaviour and it updates each linked notification relationship if the movement is deemed to be changing too.

The logic for this has been kept within the Linking business space but included as a separate service.

The `AssociatedDataService` would also be used when GVMS data is handled by BTMS and linked to import notifications, ~although it's unclear at this stage if GVMS data will actually change once it has been created~ (we now know GVMS data for an MRN will only exist for the EMBARKED status.

This PR proposes the changes for the BTMS team to review and critique.

A working assumption is that the `AssociatedDataService`'s `UpdateRelationships` method will only be called with import notifications that already exist.

Based on this PR, the query interface of BTMS will be as follows:

```
/api/import-notifications?
  filter=and(greaterOrEqual(updated,'2024-12-12T13:10:30.000Z'),lessThan(updated,'2024-12-12T13:40:30.000Z'))&
  relationshipUpdated=2024-12-12T13:10:30.000Z,2024-12-12T13:40:30.000Z
```

This will look for updated import notifications between the two dates and any movements with an updated date between the same date range too.

Some of the clarity is lost regarding how the date range is interpreted. For example, the relationship updated date is used in a filter where its value should be greater than or equal to the specified lower bound and less than the upper bound. So consumers can keep incrementing by a time period and data will not be missed.

When the Updated field of the relationship is being updated, the Updated field on the primary entity will not be changed.