### PR TITLE
PHAIN-133: Generate and save the OpenAPI spec on build

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -73,7 +73,16 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
-    
+
+      - name: Generate OpenAPI specification
+        run: make generate-openapi-spec
+
+      - name: Save OpenApi specification
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi.json
+          path: openapi.json
+
     ## SonarCloud
     ## Uncomment to unable SonarCloud scan
     ## Requires project to be set up in SonarCloud

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,14 @@ jobs:
         uses: DEFRA/cdp-build-action/build@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate OpenAPI specification
+        run: make generate-openapi-spec
+      - name: Save OpenApi specification
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi.json
+          path: openapi.json
+
   ## SonarCloud
   ## Uncomment to unable SonarCloud scan
   ## Requires project to be set up in SonarCloud


### PR DESCRIPTION
This changes the GitHub build pipelines to generate the OpenAPI spec and then save it as an artifact.

This makes it easier to update the PHA API by removing the need to clone BTMS, build and generate it.