### PR TITLE
PHAIN-133: Restore when generating the OpenAPI spec if necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ dependencies:
 	dotnet tool restore
 
 generate-openapi-spec: dependencies
-	dotnet build -c Release --no-restore
+	dotnet build -c Release
 	dotnet swagger tofile --output openapi.json ./Btms.Backend/bin/Release/net8.0/Btms.Backend.dll public-v0.1


### PR DESCRIPTION
In a main branch pipeline run it fails to generate the OpenAPI spec because the solution's dependendencies haven't been restored before.

In PR jobs the solution gets restored during the test stage.