### PR TITLE
 CDMS-357 New BusinessDecisionStatus to represent the state of MRNs in a new chart on the Decisions dashboard

### DIFF
--- a/Btms.Analytics.Tests/Helpers/TestAssertionExtensions.cs
+++ b/Btms.Analytics.Tests/Helpers/TestAssertionExtensions.cs
@@ -1,3 +1,4 @@
+using Btms.Common.Enum;
 using Btms.Model;
 using Btms.Model.Cds;
 using FluentAssertions;

--- a/Btms.Analytics.Tests/MovementsByDecisionStatusTests.cs
+++ b/Btms.Analytics.Tests/MovementsByDecisionStatusTests.cs
@@ -1,0 +1,81 @@
+using Btms.Common.Extensions;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+using Btms.Analytics.Tests.Fixtures;
+using Btms.Analytics.Tests.Helpers;
+using Btms.Common.Enum;
+using Btms.Model.Cds;
+using TestDataGenerator.Config;
+using TestGenerator.IntegrationTesting.Backend;
+
+namespace Btms.Analytics.Tests;
+
+public class MovementsByBusinessDecisionStatusTests(ITestOutputHelper output)
+    : ScenarioDatasetBaseTest(output, Datasets.FunctionalAnalyticsDecisionStatusDatasetName)
+{
+    [Fact]
+    public void ShouldHaveCorrectNumberOfMrnsInDatabase()
+    {
+        BackendFixture.MongoDbContext.Movements.Count()
+            .Should().Be(5);
+    }
+
+    [Fact]
+    public async Task ShouldFilterOutUnwantedMrns()
+    {
+        TestOutputHelper.WriteLine("Querying for aggregated data");
+        var result = await MovementsAggregationService
+            .ByBusinessDecisionStatus(DateTime.MinValue, DateTime.MaxValue, false)!;
+
+        TestOutputHelper.WriteLine("{0} aggregated items found", result!.Values);
+
+        result.Values.Sum(r => r.Value).Should().Be(4);
+    }
+
+    [Fact]
+    public async Task ShouldNotHaveCancelledOrDestroyed()
+    {
+        var result = await MovementsAggregationService
+            .ByBusinessDecisionStatus(DateTime.MinValue, DateTime.MaxValue, false)!;
+
+        result.Values.Keys.Should().NotContain(BusinessDecisionStatusEnum.CancelledOrDestroyed.GetValue());
+    }
+
+    [Fact]
+    public async Task ShouldHaveManualReleases()
+    {
+        var result = await MovementsAggregationService
+            .ByBusinessDecisionStatus(DateTime.MinValue, DateTime.MaxValue, false)!;
+
+        result.Values.Keys.Should().Contain(BusinessDecisionStatusEnum.ManualReleases.GetValue());
+    }
+
+    [Fact]
+    public async Task ShouldHaveMatchComplete()
+    {
+        var result = await MovementsAggregationService
+            .ByBusinessDecisionStatus(DateTime.MinValue, DateTime.MaxValue, false)!;
+
+        result.Values.Keys.Should().Contain(BusinessDecisionStatusEnum.MatchComplete.GetValue());
+    }
+
+    [Fact]
+    public async Task ShouldHaveAlvsReleaseBtmsNotReleased()
+    {
+        var result = await MovementsAggregationService
+            .ByBusinessDecisionStatus(DateTime.MinValue, DateTime.MaxValue, false)!;
+
+        result.Values.Keys.Should().Contain(BusinessDecisionStatusEnum.AlvsReleaseBtmsNotReleased.GetValue());
+    }
+
+    // [Fact]
+    // public async Task ShouldHaveAnythingElse()
+    // {
+    //     var result = await MovementsAggregationService
+    //         .ByBusinessDecisionStatus(DateTime.MinValue, DateTime.MaxValue, false)!;
+    //
+    //     result.Values.Keys.Should().Contain(BusinessDecisionStatusEnum.AnythingElse.GetValue());
+    // }
+}

--- a/Btms.Analytics/Extensions/MovementExtensions.cs
+++ b/Btms.Analytics/Extensions/MovementExtensions.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Contracts;
 using Btms.Model;
 using Btms.Model.Cds;
 using Btms.Model.Ipaffs;
+using Microsoft.Extensions.Logging;
 
 namespace Btms.Analytics.Extensions;
 

--- a/Btms.Analytics/IMovementsAggregationService.cs
+++ b/Btms.Analytics/IMovementsAggregationService.cs
@@ -10,6 +10,8 @@ public interface IMovementsAggregationService
     public Task<MultiSeriesDataset<ByNumericDimensionResult>> ByItemCount(DateTime from, DateTime to);
     public Task<SummarisedDataset<SingleSeriesDataset, StringBucketDimensionResult>> ByDecision(DateTime from, DateTime to, bool finalisedOnly, ImportNotificationTypeEnum[]? chedTypes = null, string? country = null);
 
+    public Task<SingleSeriesDataset> ByBusinessDecisionStatus(DateTime from, DateTime to, bool finalisedOnly, ImportNotificationTypeEnum[]? chedTypes = null, string? country = null);
+
     public Task<SingleSeriesDataset> ByAlvsDecision(DateTime from, DateTime to, bool finalisedOnly, ImportNotificationTypeEnum[]? chedTypes = null, string? country = null);
 
     public Task<MultiSeriesDataset<ByNumericDimensionResult>> ByUniqueDocumentReferenceCount(DateTime from, DateTime to);

--- a/Btms.Analytics/MovementsAggregationService.cs
+++ b/Btms.Analytics/MovementsAggregationService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using System.Linq.Expressions;
 using Btms.Analytics.Extensions;
 using Btms.Backend.Data;
+using Btms.Common.Enum;
 using Btms.Common.Extensions;
 using Btms.Model;
 using Btms.Model.Cds;
@@ -48,13 +49,11 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
             .Select(g => new { g.Key, Count = g.Count() })
             .ToDictionary(g => g.Key, g => g.Count);
 
-        var enumLookup = new JsonStringEnumConverterEx<LinkStatusEnum>();
-
         return Task.FromResult(new SingleSeriesDataset
         {
             Values = AnalyticsHelpers
                 .GetMovementStatusSegments()
-                .ToDictionary(status => enumLookup.GetValue(status), status => data.GetValueOrDefault(status, 0))
+                .ToDictionary(status => status.GetValue(), status => data.GetValueOrDefault(status, 0))
         });
     }
 
@@ -77,14 +76,12 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
         var maxCount = mongoResult.Count > 0 ?
             mongoResult.Max(r => r.Count) : 0;
 
-        var enumLookup = new JsonStringEnumConverterEx<LinkStatusEnum>();
-
         return Task.FromResult(new MultiSeriesDataset<ByNumericDimensionResult>()
         {
             Series = AnalyticsHelpers.GetMovementStatusSegments()
                 .Select(status => new Series<ByNumericDimensionResult>()
                 {
-                    Name = enumLookup.GetValue(status),
+                    Name = status.GetValue(),
                     Dimension = "Item Count",
                     Results = Enumerable.Range(0, maxCount + 1)
                             .Select(i => new ByNumericDimensionResult
@@ -124,24 +121,22 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
         var maxReferences = mongoResult.Count > 0 ?
             mongoResult.Max(r => r.DocumentReferenceCount) : 0;
 
-        var enumLookup = new JsonStringEnumConverterEx<LinkStatusEnum>();
-
         return Task.FromResult(new MultiSeriesDataset<ByNumericDimensionResult>()
         {
             Series = AnalyticsHelpers.GetMovementStatusSegments()
-                .Select(status => new Series<ByNumericDimensionResult>()
-                {
-                    Name = enumLookup.GetValue(status),
-                    Dimension = "Document Reference Count",
-                    Results = Enumerable.Range(0, maxReferences + 1)
-                        .Select(i => new ByNumericDimensionResult
-                        {
-                            Dimension = i,
-                            Value = dictionary.GetValueOrDefault(new { LinkStatus = status, DocumentReferenceCount = i },
-                                0)
-                        }).ToList()
-                })
-                .ToList()
+            .Select(status => new Series<ByNumericDimensionResult>()
+            {
+                Name = status.GetValue(),
+                Dimension = "Document Reference Count",
+                Results = Enumerable.Range(0, maxReferences + 1)
+                    .Select(i => new ByNumericDimensionResult
+                    {
+                        Dimension = i,
+                        Value = dictionary.GetValueOrDefault(new { LinkStatus = status, DocumentReferenceCount = i },
+                            0)
+                    }).ToList()
+            })
+            .ToList()
         });
     }
 
@@ -291,15 +286,60 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
             .Movements
             .GetAggregatedRecordsDictionary(logger, filter, projection, group, datasetGroup, createDatasetName);
 
-        var enumLookup = new JsonStringEnumConverterEx<LinkStatusEnum>();
-
         var output = AnalyticsHelpers.GetMovementStatusSegments()
-            .Select(status => mongoResult.AsDataset(dateRange, enumLookup.GetValue(status)))
+            .Select(status => mongoResult.AsDataset(dateRange, status.GetValue()))
             .AsOrderedArray(m => m.Name);
 
         logger.LogDebug(AggregatedMessage, output.ToList().ToJsonString());
 
         return Task.FromResult(new MultiSeriesDatetimeDataset() { Series = output.ToList() });
+    }
+
+    public Task<SingleSeriesDataset> ByBusinessDecisionStatus(DateTime from, DateTime to, bool finalisedOnly, ImportNotificationTypeEnum[]? chedTypes = null,
+        string? country = null)
+    {
+        BusinessDecisionStatusEnum[] exclude = [
+            BusinessDecisionStatusEnum.CancelledOrDestroyed
+        ];
+
+        var mongoQuery = context
+            .Movements
+            .WhereFilteredByCreatedDateAndParams(from, to, finalisedOnly, chedTypes, country)
+            .Where(m => !exclude.Contains(m.BtmsStatus.BusinessDecisionStatus))
+            .Select(m => new
+            {
+                Movement = m,
+                DecisionStatus = m.BtmsStatus.BusinessDecisionStatus
+            })
+            .GroupBy(d => new
+            {
+                d.DecisionStatus
+            })
+            .Select(g => new
+            {
+                g.Key,
+                Count = g.Count()
+            })
+            .Execute(logger);
+
+        logger.LogDebug(AggregatedMessage, mongoQuery.ToJsonString());
+
+        var values = mongoQuery
+            .GroupBy(q => q.Key.DecisionStatus)
+            .Select(g => new { g.Key, Sum = g.Sum(k => k.Count) })
+            .OrderBy(s => s.Key)
+            .ToDictionary(
+                g => g.Key.GetValue(),
+                g => g.Sum
+            );
+
+        // Works
+        var result = new SingleSeriesDataset()
+        {
+            Values = values
+        };
+
+        return Task.FromResult(result);
     }
 
     public Task<SingleSeriesDataset> ByAlvsDecision(DateTime from,
@@ -386,13 +426,12 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
 
         logger.LogDebug(AggregatedMessage, mongoQuery.ToJsonString());
 
-        var enumLookup = new JsonStringEnumConverterEx<DecisionStatusEnum>();
         var summaryValues = mongoQuery
             .GroupBy(q => q.Key.DecisionStatus)
             .Select(g => new { g.Key, Sum = g.Sum(k => k.Count) })
             .OrderBy(s => s.Key)
             .ToDictionary(
-                g => enumLookup.GetValue(g.Key),
+                g => g.Key.GetValue(),
                 g => g.Sum
             );
 
@@ -409,7 +448,7 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
             {
                 Fields = new Dictionary<string, string>()
                     {
-                        { "Classification", enumLookup.GetValue(a.Key.DecisionStatus) },
+                        { "Classification", a.Key.DecisionStatus.GetValue() },
                         { "CheckCode", a.Key.CheckCode! },
                         { "AlvsDecisionCode", a.Key.AlvsDecisionCode! },
                         { "BtmsDecisionCode", a.Key.BtmsDecisionCode! }
@@ -456,14 +495,13 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
 
         logger.LogDebug(AggregatedMessage, mongoQuery.ToJsonString());
 
-        var enumLookup = new JsonStringEnumConverterEx<MovementSegmentEnum>();
         var summaryValues = mongoQuery
             .GroupBy(q => q.Key.Segment)
             .Select(g => new { g.Key, Sum = g.Sum(k => k.Count) })
             .OrderBy(s => s.Key)
             // .Where(g => g)
             .ToDictionary(
-                g => enumLookup.GetValue(g.Key ?? MovementSegmentEnum.None),
+                g => (g.Key ?? MovementSegmentEnum.None).GetValue(),
                 g => g.Sum
             );
 
@@ -480,11 +518,7 @@ public class MovementsAggregationService(IMongoDbContext context, ILogger<Moveme
             {
                 Fields = new Dictionary<string, string>()
                     {
-                        // { "Classification", enumLookup.GetValue(a.Key!.Segment) },
-                        { "Classification", enumLookup.GetValue(a.Key.Segment ?? MovementSegmentEnum.None) },
-                        // { "CheckCode", a.Key.CheckCode! },
-                        // { "AlvsDecisionCode", a.Key.AlvsDecisionCode! },
-                        // { "BtmsDecisionCode", a.Key.BtmsDecisionCode! }
+                        { "Classification", (a.Key.Segment ?? MovementSegmentEnum.None).GetValue() }
                     },
                 Value = a.Count
             })

--- a/Btms.Backend.Cli.Tests/Features/GenerateModels/UnknownTimeZoneDateTimeTests.cs
+++ b/Btms.Backend.Cli.Tests/Features/GenerateModels/UnknownTimeZoneDateTimeTests.cs
@@ -10,9 +10,9 @@ public class UnknownTimeZoneDateTimeTests(CodeBuilderFixture fixture) : IClassFi
     private async Task<CSharpDescriptor> BuildLocalDateProperty()
     {
         var csharpDescriptor = await fixture.BuildSingleProperty(
-            "InspectionOverride",
+            "ActualCrossing",
             new PropertyDescriptor(
-                "overriddenOn",
+                "arrivesAt",
                 type: "DateTime",
                 isReferenceType: false,
                 isArray: false)
@@ -38,9 +38,9 @@ public class UnknownTimeZoneDateTimeTests(CodeBuilderFixture fixture) : IClassFi
         
         var sourceFile =
             csharpDescriptor.OutputFiles.Single(f =>
-                f.Path == "/tmp/btms-cli-tests/source/InspectionOverride.g.cs");
+                f.Path == "/tmp/btms-cli-tests/source/ActualCrossing.g.cs");
         
-        sourceFile.Content.Should().Contain("[Btms.Common.Json.UnknownTimeZoneDateTimeJsonConverter(nameof(OverriddenOn))");
+        sourceFile.Content.Should().Contain("[Btms.Common.Json.UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt))");
     }
 
     [Fact]
@@ -50,8 +50,8 @@ public class UnknownTimeZoneDateTimeTests(CodeBuilderFixture fixture) : IClassFi
         
         var sourceFile =
             csharpDescriptor.OutputFiles.Single(f =>
-                f.Path == "/tmp/btms-cli-tests/internal/InspectionOverride.g.cs");
+                f.Path == "/tmp/btms-cli-tests/internal/ActualCrossing.g.cs");
         
-        sourceFile.Content.Should().Contain("[Btms.Common.Json.UnknownTimeZoneDateTimeJsonConverter(nameof(OverriddenOn)), MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)]");
+        sourceFile.Content.Should().Contain("[Btms.Common.Json.UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt)), MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)]");
     }
 }

--- a/Btms.Backend.Cli/Features/GenerateModels/ClassMaps/Bootstrap.cs
+++ b/Btms.Backend.Cli/Features/GenerateModels/ClassMaps/Bootstrap.cs
@@ -72,12 +72,6 @@ internal static class Bootstrap
 
         GeneratorClassMap.RegisterClassMap("Check", map =>
         {
-            map.AddProperty(new PropertyDescriptor("decisionCode", "string", false, false));
-
-            map.AddProperty(new PropertyDescriptor("decisionsValidUntil", "DateTime", false, false));
-
-            map.AddProperty(new PropertyDescriptor("decisionReasons", "string", false, true));
-
             map.MapProperty("MasterUCR")
                 .SetName("masterUcr")
                 .SetSourceJsonPropertyName("masterUCR");

--- a/Btms.Backend.IntegrationTests/BusinessDecisionComparisonTests.cs
+++ b/Btms.Backend.IntegrationTests/BusinessDecisionComparisonTests.cs
@@ -1,0 +1,53 @@
+using Btms.Model.Cds;
+using FluentAssertions;
+using TestDataGenerator.Scenarios.SpecificFiles;
+using TestGenerator.IntegrationTesting.Backend;
+using TestGenerator.IntegrationTesting.Backend.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Btms.Backend.IntegrationTests;
+
+[Trait("Category", "Integration")]
+public class BusinessDecisionComparisonTests(ITestOutputHelper output) : MultipleScenarioGeneratorBaseTest(output)
+{
+
+    // // Destroyed
+    // Mrn24Gbdej9V2Od0Bhar0DestroyedScenarioGenerator
+    //         
+    // // Manual Action
+    // Mrn24Gbeds4W7Dfrlmar0ManualActionScenarioGenerator
+    //         
+    // // Cleared
+    // Mrn24Gbd2Uowtwym5Lar8ScenarioGenerator
+    //         
+    // // No Finalisation
+    // Mrn24Gbdshixsy6Rckar3ScenarioGenerator
+
+    [Theory]
+    [InlineData(typeof(ChedAh01ScenarioGenerator1), BusinessDecisionStatusEnum.AnythingElse)]
+    [InlineData(typeof(Mrn24Gbdc4Tw6Duqyiar5ScenarioGenerator), BusinessDecisionStatusEnum.AlvsNotRefusedBtmsRefused)]
+    [InlineData(typeof(Mrn24Gbdshixsy6Rckar3ScenarioGenerator), BusinessDecisionStatusEnum.MatchComplete)]
+    [InlineData(typeof(ChedWithAlvsX00WrongDocumentReferenceFormatScenarioGenerator), BusinessDecisionStatusEnum.AlvsReleaseBtmsNotReleased)]
+    [InlineData(typeof(Mrn24Gbdej9V2Od0Bhar0DestroyedScenarioGenerator), BusinessDecisionStatusEnum.CancelledOrDestroyed)]
+    [InlineData(typeof(Mrn24Gbeds4W7Dfrlmar0ManualActionScenarioGenerator), BusinessDecisionStatusEnum.ManualReleases)]
+    public void ShouldHaveCorrectDecisionCode(Type generatorType, BusinessDecisionStatusEnum decisionStatus)
+    {
+        base.TestOutputHelper.WriteLine("Generator : {0}, Decision Status : {1}", generatorType!.FullName, decisionStatus);
+        EnsureEnvironmentInitialised(generatorType);
+        CheckDecisionStatus(decisionStatus);
+    }
+
+    private void CheckDecisionStatus(BusinessDecisionStatusEnum decisionStatus)
+    {
+        var movement =
+            Client
+                .GetSingleMovement();
+
+        TestOutputHelper.WriteLine("MRN {0}, expectedDecisionStatus {1}", movement.EntryReference, decisionStatus);
+
+        movement
+            .BtmsStatus.BusinessDecisionStatus
+            .Should().Be(decisionStatus);
+    }
+}

--- a/Btms.Backend/Config/AnalyticsDashboards.cs
+++ b/Btms.Backend/Config/AnalyticsDashboards.cs
@@ -16,16 +16,6 @@ public class DateRange
     public DateTime? From { get; set; }
     [FromQuery(Name = "dateTo")]
     public DateTime? To { get; set; }
-
-    // public static DateRange Default()
-    // {
-    //     return new DateRange() { From = DateTime.Now, To = DateTime.Now };
-    // }
-    // public static bool TryParse(string query, out DateRange dateRange)
-    // {
-    //     dateRange = new DateRange() { From = DateTime.Now, To = DateTime.Now };
-    //     return true;
-    // }
 }
 
 public static class AnalyticsDashboards
@@ -118,6 +108,10 @@ public static class AnalyticsDashboards
             {
                 "lastMonthImportNotificationsByCommodityCount",
                 () => importService.ByCommodityCount(DateTime.Today.MonthAgo(), DateTime.Now).AsIDataset()
+            },
+            {
+                "decisionsByBusinessDecisionStatus",
+                () => movementsService.ByBusinessDecisionStatus(dateRange.From ?? DateTime.Today.MonthAgo(), dateRange.To ?? DateTime.Now, finalisedOnly, chedTypes, country).AsIDataset()
             },
             {
                 "decisionsByDecisionCode",

--- a/Btms.Business.Tests/BusinessDecisionStatusEnumFinderTests.cs
+++ b/Btms.Business.Tests/BusinessDecisionStatusEnumFinderTests.cs
@@ -1,0 +1,18 @@
+using Btms.Business.Builders;
+using Btms.Business.Commands;
+using Btms.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace Btms.Business.Tests;
+
+public class BusinessDecisionStatusFinderTests
+{
+    [Fact]
+    public void EnsureWeHaveAllStatusFinders()
+    {
+        //An exception would be thrown if it doesn't
+        var decisionFinder = new BusinessDecisionStatusFinder();
+        decisionFinder.Should().NotBeNull();
+    }
+}

--- a/Btms.Business.Tests/Models/JsonStringEnumConverterExTests.cs
+++ b/Btms.Business.Tests/Models/JsonStringEnumConverterExTests.cs
@@ -1,3 +1,4 @@
+using Btms.Common.Enum;
 using Btms.Model;
 using Btms.Model.Cds;
 using FluentAssertions;

--- a/Btms.Business.Tests/PreProcessing/MovementPreProcessingTests.cs
+++ b/Btms.Business.Tests/PreProcessing/MovementPreProcessingTests.cs
@@ -18,7 +18,7 @@ public class MovementPreProcessingTests
         // ARRANGE
         var clearanceRequest = CreateAlvsClearanceRequest();
         var dbContext = new MemoryMongoDbContext();
-        var preProcessor = new MovementPreProcessor(dbContext, NullLogger<MovementPreProcessor>.Instance, new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance));
+        var preProcessor = new MovementPreProcessor(dbContext, NullLogger<MovementPreProcessor>.Instance, new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance));
 
         // ACT
         var preProcessingResult = await preProcessor.Process(

--- a/Btms.Business.Tests/Services/Decisions/DecisionServiceTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/DecisionServiceTests.cs
@@ -101,6 +101,7 @@ public class DecisionServiceTests
         _serviceCollection.AddSingleton(Substitute.For<IPublishBus>());
         _serviceCollection.AddSingleton<MovementBuilderFactory>();
         _serviceCollection.AddSingleton<DecisionStatusFinder>();
+        _serviceCollection.AddSingleton<BusinessDecisionStatusFinder>();
         _serviceCollection.AddLogging();
         _serviceCollection.AddSingleton<IMongoDbContext, MemoryMongoDbContext>();
     }

--- a/Btms.Business.Tests/Services/Decisions/NoMatchDecisionsTest.cs
+++ b/Btms.Business.Tests/Services/Decisions/NoMatchDecisionsTest.cs
@@ -32,7 +32,7 @@ public class NoMatchDecisionsTest
 
         var sut = new DecisionService(NullLogger<DecisionService>.Instance,
             Array.Empty<IDecisionFinder>(),
-            new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance),
+            new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance),
             new MemoryMongoDbContext());
 
         var matchingResult = new MatchingResult();
@@ -59,7 +59,7 @@ public class NoMatchDecisionsTest
 
         var sut = new DecisionService(NullLogger<DecisionService>.Instance,
             Array.Empty<IDecisionFinder>(),
-            new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance),
+            new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance),
             new MemoryMongoDbContext());
 
         var matchingResult = new MatchingResult();
@@ -85,7 +85,7 @@ public class NoMatchDecisionsTest
 
         var sut = new DecisionService(NullLogger<DecisionService>.Instance,
             Array.Empty<IDecisionFinder>(),
-            new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance),
+            new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance),
             new MemoryMongoDbContext());
 
         var matchingResult = new MatchingResult();
@@ -112,7 +112,7 @@ public class NoMatchDecisionsTest
 
         var config = ScenarioFactory.CreateScenarioConfig(generator, 1, 1);
 
-        var movementBuilderFactory = new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
+        var movementBuilderFactory = new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
         var generatorResult = generator
             .Generate(1, 1, DateTime.UtcNow, config)
             .First(x => x is AlvsClearanceRequest);

--- a/Btms.Business.Tests/Services/Matching/MatchingServiceTests.cs
+++ b/Btms.Business.Tests/Services/Matching/MatchingServiceTests.cs
@@ -76,7 +76,7 @@ public class MatchingServiceTests
     {
         CrNoMatchScenarioGenerator generator =
             new CrNoMatchScenarioGenerator(NullLogger<CrNoMatchScenarioGenerator>.Instance);
-        var movementBuilderFactory = new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
+        var movementBuilderFactory = new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
         var config = ScenarioFactory.CreateScenarioConfig(generator, 1, 1);
 
         var generatorResult = generator
@@ -97,7 +97,7 @@ public class MatchingServiceTests
         ChedASimpleMatchScenarioGenerator generator =
             new ChedASimpleMatchScenarioGenerator(NullLogger<ChedASimpleMatchScenarioGenerator>.Instance);
         var config = ScenarioFactory.CreateScenarioConfig(generator, 1, 1);
-        var movementBuilderFactory = new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
+        var movementBuilderFactory = new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
 
         var generatorResult = generator.Generate(1, 1, DateTime.UtcNow, config);
 

--- a/Btms.Business/Builders/BusinessDecisionStatusFinder.cs
+++ b/Btms.Business/Builders/BusinessDecisionStatusFinder.cs
@@ -1,0 +1,132 @@
+using Btms.Common.Extensions;
+using Btms.Model;
+using Btms.Model.Cds;
+using Btms.Model.Ipaffs;
+
+namespace Btms.Business.Builders;
+
+public class BusinessDecisionStatusFinder
+{
+    private readonly Dictionary<BusinessDecisionStatusEnum, Func<Movement, bool>> _finders = [];
+    private readonly List<BusinessDecisionStatusEnum> _orderedFinders = Enum.GetValues<BusinessDecisionStatusEnum>().ToList();
+    public BusinessDecisionStatusFinder()
+    {
+        _finders.Add(BusinessDecisionStatusEnum.CancelledOrDestroyed, CancelledOrDestroyed);
+        _finders.Add(BusinessDecisionStatusEnum.ManualReleases, ManualReleases);
+        _finders.Add(BusinessDecisionStatusEnum.MatchComplete, MatchComplete);
+        _finders.Add(BusinessDecisionStatusEnum.MatchGroup, MatchGroup);
+        _finders.Add(BusinessDecisionStatusEnum.AlvsHoldBtmsNotHeld, AlvsHoldBtmsNotHeld);
+        _finders.Add(BusinessDecisionStatusEnum.AlvsNotHeldBtmsHold, AlvsNotHeldBtmsHold);
+        _finders.Add(BusinessDecisionStatusEnum.AlvsReleaseBtmsNotReleased, AlvsReleaseBtmsNotReleased);
+        _finders.Add(BusinessDecisionStatusEnum.AlvsNotReleasedBtmsReleased, AlvsNotReleasedBtmsReleased);
+        _finders.Add(BusinessDecisionStatusEnum.AlvsRefuseBtmsNotRefused, AlvsRefuseBtmsNotRefused);
+        _finders.Add(BusinessDecisionStatusEnum.AlvsNotRefusedBtmsRefused, AlvsNotRefusedBtmsRefused);
+        _finders.Add(BusinessDecisionStatusEnum.AlvsDataErrorDecision, AlvsDataErrorDecision);
+        _finders.Add(BusinessDecisionStatusEnum.BtmsDataErrorDecision, BtmsDataErrorDecision);
+
+        // Default if none of the above match - AnythingElse needs to be the last one in the Enum
+        _finders.Add(BusinessDecisionStatusEnum.AnythingElse, m => true);
+
+        //Validate that each status in the enum has a finder
+        var hasFinders = _finders.Select(f => f.Key).ToArray();
+
+        var missing = _orderedFinders
+            .Except(hasFinders);
+
+        if (missing.Any())
+        {
+            throw new InvalidOperationException("Decision Status Finders missing in DecisionStatusFinder");
+        }
+    }
+
+    public BusinessDecisionStatusEnum GetStatus(Movement movement)
+    {
+        return _orderedFinders
+            .First(f => _finders[f](movement));
+    }
+
+    private static readonly FinalState[] cancelledOrDestroyed = [
+        FinalState.CancelledAfterArrival,
+        FinalState.CancelledWhilePreLodged,
+        FinalState.Destroyed,
+        FinalState.Seized,
+        FinalState.ReleasedToKingsWarehouse,
+        FinalState.TransferredToMss
+    ];
+
+    private static bool CancelledOrDestroyed(Movement movement)
+    {
+        return movement.Finalisation.HasValue() && cancelledOrDestroyed.Contains(movement.Finalisation!.FinalState);
+    }
+
+    private static bool ManualReleases(Movement movement)
+    {
+        return movement.Finalisation?.ManualAction == true;
+    }
+
+    private static bool MatchComplete(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.DecisionStatus ==
+               DecisionStatusEnum.BtmsMadeSameDecisionAsAlvs;
+    }
+
+    private static bool MatchGroup(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.DecisionStatus ==
+               DecisionStatusEnum.BtmMadeSameDecisionTypeAsAlvs;
+    }
+
+    private static bool AlvsHoldBtmsNotHeld(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            c.AlvsDecisionCode.StartsWith('H') &&
+            !(c.BtmsDecisionCode?.StartsWith('H') ?? false)) ?? false;
+    }
+
+    private static bool AlvsNotHeldBtmsHold(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            !c.AlvsDecisionCode.StartsWith('H') &&
+            (c.BtmsDecisionCode?.StartsWith('H') ?? false)) ?? false;
+    }
+
+    private static bool AlvsReleaseBtmsNotReleased(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            c.AlvsDecisionCode.StartsWith('C') &&
+            !(c.BtmsDecisionCode?.StartsWith('C') ?? false)) ?? false;
+    }
+
+    private static bool AlvsNotReleasedBtmsReleased(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            !c.AlvsDecisionCode.StartsWith('C') &&
+            (c.BtmsDecisionCode?.StartsWith('C') ?? false)) ?? false;
+    }
+
+    private static bool AlvsRefuseBtmsNotRefused(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            c.AlvsDecisionCode.StartsWith('N') &&
+            !(c.BtmsDecisionCode?.StartsWith('N') ?? false)) ?? false;
+    }
+
+    private static bool AlvsNotRefusedBtmsRefused(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            !c.AlvsDecisionCode.StartsWith('N') &&
+            (c.BtmsDecisionCode?.StartsWith('N') ?? false)) ?? false;
+    }
+
+    private static bool AlvsDataErrorDecision(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            c.AlvsDecisionCode.StartsWith('E')) ?? false;
+    }
+
+    private static bool BtmsDataErrorDecision(Movement movement)
+    {
+        return movement.AlvsDecisionStatus.Context.DecisionComparison?.Checks.Any(c =>
+            c.BtmsDecisionCode?.StartsWith('E') ?? false) ?? false;
+    }
+}

--- a/Btms.Business/Builders/DecisionStatusFinder.cs
+++ b/Btms.Business/Builders/DecisionStatusFinder.cs
@@ -7,8 +7,7 @@ namespace Btms.Business.Builders;
 public class DecisionStatusFinder
 {
     private readonly Dictionary<DecisionStatusEnum, Func<Movement, AlvsDecision, bool>> _finders = [];
-    private readonly List<DecisionStatusEnum> _orderedDecisions = Enum.GetValues<DecisionStatusEnum>().ToList();
-
+    private readonly List<DecisionStatusEnum> _orderedFinders = Enum.GetValues<DecisionStatusEnum>().ToList();
     public DecisionStatusFinder()
     {
         _finders.Add(DecisionStatusEnum.BtmsMadeSameDecisionAsAlvs, BtmsMadeSameDecisionAsAlvs);
@@ -39,7 +38,7 @@ public class DecisionStatusFinder
         //Validate that each status in the enum has a finder
         var hasFinders = _finders.Select(f => f.Key).ToArray();
 
-        var missing = _orderedDecisions
+        var missing = _orderedFinders
             .Except(hasFinders);
 
         if (missing.Any())
@@ -48,9 +47,9 @@ public class DecisionStatusFinder
         }
     }
 
-    public DecisionStatusEnum GetDecisionStatus(Movement movement, AlvsDecision decision)
+    public DecisionStatusEnum GetStatus(Movement movement, AlvsDecision decision)
     {
-        return _orderedDecisions
+        return _orderedFinders
             .First(f => _finders[f](movement, decision));
     }
 

--- a/Btms.Business/Builders/MovementBuilder.cs
+++ b/Btms.Business/Builders/MovementBuilder.cs
@@ -9,7 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Btms.Business.Builders;
 
-public class MovementBuilder(ILogger<MovementBuilder> logger, DecisionStatusFinder decisionStatusFinder, Movement movement, bool hasChanges = false)
+public class MovementBuilder(ILogger<MovementBuilder> logger, DecisionStatusFinder decisionStatusFinder, BusinessDecisionStatusFinder businessDecisionFinder, Movement movement, bool hasChanges = false)
 {
     private readonly Movement? _movement = movement;
     public bool HasChanges = hasChanges;
@@ -381,7 +381,7 @@ public class MovementBuilder(ILogger<MovementBuilder> logger, DecisionStatusFind
         alvsDecision.Context.BtmsCheckStatus = GeBtmsCheckStatus(alvsChecks);
 
         var decisionStatus =
-            decisionStatusFinder.GetDecisionStatus(_movement, alvsDecision);
+            decisionStatusFinder.GetStatus(_movement, alvsDecision);
 
         if (decisionStatus == DecisionStatusEnum.BtmsMadeSameDecisionAsAlvs)
         {
@@ -394,6 +394,9 @@ public class MovementBuilder(ILogger<MovementBuilder> logger, DecisionStatusFind
     public Movement Build()
     {
         GuardNullMovement();
+
+        _movement.BtmsStatus.BusinessDecisionStatus = businessDecisionFinder.GetStatus(_movement);
+
         return _movement;
     }
 }

--- a/Btms.Business/Builders/MovementBuilderFactory.cs
+++ b/Btms.Business/Builders/MovementBuilderFactory.cs
@@ -7,7 +7,7 @@ using Btms.Model.Ipaffs;
 
 namespace Btms.Business.Builders;
 
-public class MovementBuilderFactory(DecisionStatusFinder decisionStatusFinder, ILogger<MovementBuilder> logger)
+public class MovementBuilderFactory(DecisionStatusFinder decisionStatusFinder, BusinessDecisionStatusFinder businessDecisionStatusFinder, ILogger<MovementBuilder> logger)
 {
     public MovementBuilder From(CdsClearanceRequest request)
     {
@@ -36,12 +36,12 @@ public class MovementBuilderFactory(DecisionStatusFinder decisionStatusFinder, I
             BtmsStatus = MovementExtensions.GetMovementStatus(GetChedTypes(request.Items!.ToList()), documentReferenceIds, notificationRelationshipIds)
         };
 
-        return new MovementBuilder(logger, decisionStatusFinder, movement, true);
+        return new MovementBuilder(logger, decisionStatusFinder, businessDecisionStatusFinder, movement, true);
     }
 
     public MovementBuilder From(Movement movement)
     {
-        return new MovementBuilder(logger, decisionStatusFinder, movement, true);
+        return new MovementBuilder(logger, decisionStatusFinder, businessDecisionStatusFinder, movement, true);
     }
 
     private ImportNotificationTypeEnum[] GetChedTypes(List<Items>? items = null)

--- a/Btms.Business/Extensions/ServiceCollectionExtensions.cs
+++ b/Btms.Business/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Btms.Business.Services.Decisions.Finders;
 using Btms.Business.Services.Linking;
 using Btms.Business.Services.Matching;
 using Btms.Business.Services.Validating;
+using Btms.Model.Cds;
 using Btms.Types.Alvs;
 using Btms.Types.Gvms;
 
@@ -82,6 +83,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IDecisionFinder, IuuDecisionFinder>();
 
         services.AddTransient<DecisionStatusFinder>();
+        services.AddTransient<BusinessDecisionStatusFinder>();
         services.AddTransient<MovementBuilderFactory>();
         services.AddScoped<IPreProcessor<ImportNotification, Model.Ipaffs.ImportNotification>, ImportNotificationPreProcessor>();
         services.AddScoped<IPreProcessor<AlvsClearanceRequest, Model.Movement>, MovementPreProcessor>();

--- a/Btms.Common/Enum/EnumExtensions.cs
+++ b/Btms.Common/Enum/EnumExtensions.cs
@@ -1,0 +1,26 @@
+namespace Btms.Common.Enum;
+
+public static class EnumExtensions
+{
+    private static readonly Dictionary<string, object> converters =
+        new Dictionary<string, object>();
+
+    public static string GetValue<TEnum>(this TEnum e) where TEnum : struct, System.Enum
+    {
+        var key = e.GetType()!.FullName!;
+        if (!converters.TryGetValue(key, out var enumObject))
+        {
+            enumObject = new JsonStringEnumConverterEx<TEnum>();
+            converters.Add(key, enumObject);
+        }
+
+        var enumLookup = (JsonStringEnumConverterEx<TEnum>)enumObject;
+
+        return enumLookup.GetValue(e);
+    }
+
+    public static bool IsAny<T>(this T e, params T[] args) where T : struct, IComparable
+    {
+        return args.Any(a => e.Equals(a));
+    }
+}

--- a/Btms.Common/Enum/JsonStringEnumConverterEx.cs
+++ b/Btms.Common/Enum/JsonStringEnumConverterEx.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Btms.Common.Extensions;
 
-namespace Btms.Model;
+namespace Btms.Common.Enum;
 
 public class JsonStringEnumConverterEx<TEnum> : JsonConverter<TEnum> where TEnum : struct, System.Enum
 {
@@ -15,7 +15,7 @@ public class JsonStringEnumConverterEx<TEnum> : JsonConverter<TEnum> where TEnum
     {
         var type = typeof(TEnum);
 
-        foreach (var value in Enum.GetValues<TEnum>())
+        foreach (var value in System.Enum.GetValues<TEnum>())
         {
             var enumMember = type.GetMember(value.ToString())[0];
             var attr = enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false)
@@ -73,7 +73,6 @@ public class JsonStringEnumConverterEx<TEnum> : JsonConverter<TEnum> where TEnum
     public string[] GetValues()
     {
         return _enumToString.Values.ToArray();
-        // return _enumToString.Keys.ToArray<string>();
     }
 
     public string GetValue(TEnum value)

--- a/Btms.Common/Extensions/EnumExtensions.cs
+++ b/Btms.Common/Extensions/EnumExtensions.cs
@@ -1,9 +1,0 @@
-namespace Btms.Common.Extensions;
-
-public static class EnumExtensions
-{
-    public static bool IsAny<T>(this T e, params T[] args) where T : struct, IComparable
-    {
-        return args.Any(a => e.Equals(a));
-    }
-}

--- a/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
+++ b/Btms.Consumers.Tests/ClearanceRequestConsumerTests.cs
@@ -37,7 +37,7 @@ public class ClearanceRequestConsumerTests
     {
         // ARRANGE
         var clearanceRequest = CreateAlvsClearanceRequest();
-        var mbFactory = new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
+        var mbFactory = new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
         var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
         mb.Update(AuditEntry.CreateLinked("Test", 1));
         var movement = mb.Build();
@@ -58,7 +58,7 @@ public class ClearanceRequestConsumerTests
     {
         // ARRANGE
         var clearanceRequest = CreateAlvsClearanceRequest();
-        var mbFactory = new MovementBuilderFactory(new DecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
+        var mbFactory = new MovementBuilderFactory(new DecisionStatusFinder(), new BusinessDecisionStatusFinder(), NullLogger<MovementBuilder>.Instance);
         var mb = mbFactory.From(AlvsClearanceRequestMapper.Map(clearanceRequest));
         mb.Update(mb.CreateAuditEntry("Test", CreatedBySystem.Cds));
         var movement = mb.Build();

--- a/Btms.Model/Auditing/AuditEntry.cs
+++ b/Btms.Model/Auditing/AuditEntry.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Btms.Common.Enum;
 using Btms.Model.Cds;
 using Btms.Model.ChangeLog;
 using Btms.Common.Extensions;

--- a/Btms.Model/Cds/AlvsDecision.cs
+++ b/Btms.Model/Cds/AlvsDecision.cs
@@ -13,6 +13,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 using System.Text.Json.Serialization;
 using System.Dynamic;
 using System.Runtime.Serialization;
+using Btms.Common.Enum;
 using Btms.Model.Auditing;
 using Btms.Model.Ipaffs;
 using MongoDB.Bson.Serialization.Attributes;
@@ -176,6 +177,12 @@ public class MovementStatus
     [System.ComponentModel.Description("")]
     [MongoDB.Bson.Serialization.Attributes.BsonRepresentation(MongoDB.Bson.BsonType.String)]
     public MovementSegmentEnum? Segment { get; set; }
+
+
+    [Attr]
+    [System.ComponentModel.Description("")]
+    [MongoDB.Bson.Serialization.Attributes.BsonRepresentation(MongoDB.Bson.BsonType.String)]
+    public BusinessDecisionStatusEnum BusinessDecisionStatus { get; set; } = BusinessDecisionStatusEnum.AnythingElse;
 }
 
 [JsonConverter(typeof(JsonStringEnumConverterEx<LinkStatusEnum>))]
@@ -198,6 +205,52 @@ public enum LinkStatusEnum
 
     [EnumMember(Value = "Investigate")]
     Investigate
+}
+
+
+[JsonConverter(typeof(JsonStringEnumConverterEx<BusinessDecisionStatusEnum>))]
+public enum BusinessDecisionStatusEnum
+{
+    [EnumMember(Value = "Cancelled Or Destroyed")]
+    CancelledOrDestroyed,
+
+    [EnumMember(Value = "Manual Releases")]
+    ManualReleases,
+
+    [EnumMember(Value = "ALVS Data Error Decision")]
+    AlvsDataErrorDecision,
+
+    [EnumMember(Value = "BTMS Data Error Decision")]
+    BtmsDataErrorDecision,
+
+    [EnumMember(Value = "Match - Complete Match")]
+    MatchComplete,
+
+    [EnumMember(Value = "Match - Group Match")]
+    MatchGroup,
+
+    [EnumMember(Value = "ALVS Hold, BTMS Not Held")]
+    AlvsHoldBtmsNotHeld,
+
+    [EnumMember(Value = "ALVS Not Held, BTMS Hold")]
+    AlvsNotHeldBtmsHold,
+
+
+    [EnumMember(Value = "ALVS Release, BTMS Not Released")]
+    AlvsReleaseBtmsNotReleased,
+
+    [EnumMember(Value = "ALVS Not Released, BTMS Released")]
+    AlvsNotReleasedBtmsReleased,
+
+
+    [EnumMember(Value = "ALVS Refuse, BTMS Not Refused")]
+    AlvsRefuseBtmsNotRefused,
+
+    [EnumMember(Value = "ALVS Not Refused, BTMS Refused")]
+    AlvsNotRefusedBtmsRefused,
+
+    [EnumMember(Value = "Anything Else")]
+    AnythingElse,
 }
 
 [JsonConverter(typeof(JsonStringEnumConverterEx<DecisionStatusEnum>))]

--- a/Btms.Model/Extensions/ImportNotificationTypeEnumExtensions.cs
+++ b/Btms.Model/Extensions/ImportNotificationTypeEnumExtensions.cs
@@ -1,4 +1,5 @@
 using Btms.Model.Ipaffs;
+using Btms.Common.Enum;
 
 namespace Btms.Common.Extensions;
 
@@ -24,7 +25,7 @@ public static class ImportNotificationTypeEnumExtensions
 
     public static string FromImportNotificationTypeEnumString(this string s)
     {
-        var e = Enum.Parse<ImportNotificationTypeEnum>(s);
+        var e = System.Enum.Parse<ImportNotificationTypeEnum>(s);
         return e.AsString();
     }
 }

--- a/Btms.Types.Alvs.V1/Decision.cs
+++ b/Btms.Types.Alvs.V1/Decision.cs
@@ -13,7 +13,7 @@ namespace Btms.Types.Alvs;
 /// selecting consumers via the DI container. We'll also start to
 /// Plan is to follow the same approach as other types (currently generated) in time.
 /// </summary>
-public class Decision //
+public class Decision
 {
 
 

--- a/Btms.Types.Tests/UnknownTimeZoneDateTimeJsonConverterTests.cs
+++ b/Btms.Types.Tests/UnknownTimeZoneDateTimeJsonConverterTests.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using Btms.Common.Extensions;
-using Btms.Model.Ipaffs;
+using Btms.Model.Gvms;
 using FluentAssertions;
 
 namespace Btms.Types.Tests;
@@ -13,36 +13,36 @@ public class UnknownTimeZoneDateTimeJsonConverterTests
     public void CorrectlySerialises()
     {
         var d = DateTime.SpecifyKind(dt, DateTimeKind.Unspecified);
-        var applicant = new Applicant() { SampledOn = d };
+        var applicant = new ActualCrossing() { ArrivesAt = d };
         var s = applicant.ToJsonString();
-        s.Should().Be("{\"sampledOn\":\"2024-01-01T12:00:00\"}");
+        s.Should().Be("{\"arrivesAt\":\"2024-01-01T12:00:00\"}");
     }
     
     [Fact]
     public void CorrectlyDeserialisesTimeWithMilliseconds()
     {
-        var s = "{ \"overriddenOn\":\"2024-01-01T12:00:00.00\"}";
-        var inspectionOverride = JsonSerializer.Deserialize<Btms.Types.Ipaffs.InspectionOverride>(s)!;
-        inspectionOverride.OverriddenOn.Should().Be(dt);
-        inspectionOverride.OverriddenOn!.Value.Kind.Should().Be(DateTimeKind.Unspecified);
+        var s = "{ \"arrivesAt\":\"2024-01-01T12:00:00.00\"}";
+        var inspectionOverride = JsonSerializer.Deserialize<ActualCrossing>(s)!;
+        inspectionOverride.ArrivesAt.Should().Be(dt);
+        inspectionOverride.ArrivesAt!.Value.Kind.Should().Be(DateTimeKind.Unspecified);
     }
     
     [Fact]
     public void CorrectlyDeserialises()
     {
-        var s = "{ \"overriddenOn\":\"2024-01-01T12:00\"}";
-        var inspectionOverride = JsonSerializer.Deserialize<Btms.Types.Ipaffs.InspectionOverride>(s)!;
-        inspectionOverride.OverriddenOn.Should().Be(dt);
-        inspectionOverride.OverriddenOn!.Value.Kind.Should().Be(DateTimeKind.Unspecified);
+        var s = "{ \"arrivesAt\":\"2024-01-01T12:00\"}";
+        var inspectionOverride = JsonSerializer.Deserialize<ActualCrossing>(s)!;
+        inspectionOverride.ArrivesAt.Should().Be(dt);
+        inspectionOverride.ArrivesAt!.Value.Kind.Should().Be(DateTimeKind.Unspecified);
     }
     
     [Fact]
     public void ThrowsExceptionDuringDeserialisationForUtcDate()
     {
-        var s = "{ \"overriddenOn\":\"2024-01-01T12:00:00.00Z\"}";
+        var s = "{ \"arrivesAt\":\"2024-01-01T12:00:00.00Z\"}";
         
-        Action act = () => JsonSerializer.Deserialize<Btms.Types.Ipaffs.InspectionOverride>(s);
+        Action act = () => JsonSerializer.Deserialize<ActualCrossing>(s);
         act.Should().Throw<FormatException>()
-            .WithMessage($"Invalid Value in OverriddenOn, value=2024-01-01T12:00:00.00Z. Unknown TimeZone dates must be DateTimeKind.Unspecified, not Utc");
+            .WithMessage($"Invalid Value in {nameof(ActualCrossing.ArrivesAt)}, value=2024-01-01T12:00:00.00Z. Unknown TimeZone dates must be DateTimeKind.Unspecified, not Utc");
     }
 }

--- a/TestDataGenerator/Config/Datasets.cs
+++ b/TestDataGenerator/Config/Datasets.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using TestDataGenerator.Scenarios;
+using TestDataGenerator.Scenarios.SpecificFiles;
 using AllChedsNoMatchScenarioGenerator = TestDataGenerator.Scenarios.SpecificFiles.AllChedsNoMatchScenarioGenerator;
 
 namespace TestDataGenerator.Config;
@@ -16,6 +17,7 @@ public class Datasets(IHost app)
 {
     public const string FunctionalAnalyticsDatasetName = "Functional-Analytics";
     public const string FunctionalAnalyticsDecisionsDatasetName = "Functional-Analytics-Decisions";
+    public const string FunctionalAnalyticsDecisionStatusDatasetName = "Functional-Analytics-DecisionStatus";
 
     public static Dataset[] GetDatasets(IHost app)
     {
@@ -31,7 +33,8 @@ public class Datasets(IHost app)
             ds.LoadTestCondensed,
             ds.LoadTest90Dx10k,
             ds.FunctionalAnalytics,
-            ds.FunctionalAnalyticsDecisions
+            ds.FunctionalAnalyticsDecisions,
+            ds.FunctionalAnalyticsDecisionStatus
         ];
     }
 
@@ -68,6 +71,31 @@ public class Datasets(IHost app)
         {
             app.Services.CreateScenarioConfig<CrNoMatchSingleItemWithDecisionScenarioGenerator>(2, 2, arrivalDateRange: 0),
             app.Services.CreateScenarioConfig<CrNoMatchNoDecisionScenarioGenerator>(2, 2, arrivalDateRange: 2),
+        }
+    };
+
+
+    public readonly Dataset FunctionalAnalyticsDecisionStatus = new()
+    {
+        Name = FunctionalAnalyticsDecisionStatusDatasetName,
+        Description = "Functional Testing Analytics Dataset for testing business decision status chart",
+        RootPath = "FUNCTIONAL-ANALYTICS-DECISION-STATUS",
+        Scenarios = new[]
+        {
+            // Same BTMS & ALVS Decision
+            app.Services.CreateScenarioConfig<Mrn24Gbddjer3Zfrmzar9ScenarioGenerator>(1, 1, arrivalDateRange: 0),
+            
+            // Destroyed
+            app.Services.CreateScenarioConfig<Mrn24Gbdej9V2Od0Bhar0DestroyedScenarioGenerator>(1, 1, arrivalDateRange: 0),
+            
+            // Manual Action
+            app.Services.CreateScenarioConfig<Mrn24Gbeds4W7Dfrlmar0ManualActionScenarioGenerator>(1, 1, arrivalDateRange: 0),
+            
+            // Cleared
+            app.Services.CreateScenarioConfig<Mrn24Gbd2Uowtwym5Lar8ScenarioGenerator>(1, 1, arrivalDateRange: 0),
+            
+            // No Finalisation
+            app.Services.CreateScenarioConfig<Mrn24Gbdshixsy6Rckar3ScenarioGenerator>(1, 1, arrivalDateRange: 0),
         }
     };
 
@@ -168,16 +196,4 @@ public class Datasets(IHost app)
                 app.Services.CreateScenarioConfig<Scenarios.ChedP.SimpleMatchScenarioGenerator>(1, 90)
             }
     };
-
-    // public readonly Dataset Pha = new()
-    // {
-    //     Name = "PHA",
-    //     Description = "",
-    //     RootPath = "GENERATED-PHA",
-    //     Scenarios = new[]
-    //     {
-    //         app.CreateScenarioConfig<ChedASimpleMatchScenarioGenerator>(10, 30),
-    //         app.CreateScenarioConfig<ChedAManyCommoditiesScenarioGenerator>(10, 30)
-    //     }
-    // };
 }

--- a/TestDataGenerator/Scenarios/SpecificFiles/Mrn24Gbde3Cf94H96Tar0ModifiedScenarioGenerator.cs
+++ b/TestDataGenerator/Scenarios/SpecificFiles/Mrn24Gbde3Cf94H96Tar0ModifiedScenarioGenerator.cs
@@ -6,7 +6,7 @@ namespace TestDataGenerator.Scenarios.SpecificFiles;
 
 public class Mrn24Gbde3Cf94H96Tar0ModifiedScenarioGenerator(IServiceProvider sp, ILogger<Mrn24Gbde3Cf94H96Tar0ScenarioGenerator> logger) : SpecificFilesScenarioGenerator(sp, logger, "Mrn-24GBDE3CF94H96TAR0")
 {
-    protected override List<(string filePath, IBaseBuilder builder)> ModifyBuilders(List<(string filePath, IBaseBuilder builder)> builders)
+    protected override List<(string filePath, IBaseBuilder builder)> ModifyBuilders(List<(string filePath, IBaseBuilder builder)> builders, int? scenario = null, int? item = null, DateTime? entryDate = null)
     {
         var decisionV1Builder =
             (DecisionBuilder)builders.Single(b => b.filePath ==

--- a/TestDataGenerator/Scenarios/SpecificFiles/Mrn24Gbeds4W7Dfrlmar0ManualActionScenarioGenerator.cs
+++ b/TestDataGenerator/Scenarios/SpecificFiles/Mrn24Gbeds4W7Dfrlmar0ManualActionScenarioGenerator.cs
@@ -4,18 +4,17 @@ using TestDataGenerator.Extensions;
 
 namespace TestDataGenerator.Scenarios.SpecificFiles;
 
-public class Mrn24Gbdej9V2Od0Bhar0DestroyedScenarioGenerator(IServiceProvider sp, ILogger<Mrn24Gbdej9V2Od0Bhar0DestroyedScenarioGenerator> logger) :
-    SpecificFilesScenarioGenerator(sp, logger, "Mrn-24GBDEJ9V2OD0BHAR0")
+public class Mrn24Gbeds4W7Dfrlmar0ManualActionScenarioGenerator(IServiceProvider sp, ILogger<Mrn24Gbdej9V2Od0Bhar0ManualActionScenarioGenerator> logger) : SpecificFilesScenarioGenerator(sp, logger, "Mrn-24GBEDS4W7DFRLMAR0")
 {
     protected override List<(string filePath, IBaseBuilder builder)> ModifyBuilders(List<(string filePath, IBaseBuilder builder)> builders, int? scenario = null, int? item = null, DateTime? entryDate = null)
     {
         builders = base.ModifyBuilders(builders, scenario, item, entryDate);
 
         foreach (var builderItem in builders
-            .Where(b => b.builder is FinalisationBuilder))
+                     .Where(b => b.builder is FinalisationBuilder))
         {
             ((FinalisationBuilder)builderItem.builder)
-                .WithFinalState(3);
+                .WithManualAction(true);
         }
 
         return builders;

--- a/TestDataGenerator/Scenarios/SpecificFiles/SpecificFilesScenarioGenerator.cs
+++ b/TestDataGenerator/Scenarios/SpecificFiles/SpecificFilesScenarioGenerator.cs
@@ -145,11 +145,12 @@ public class Mrn24Gbdzsrxdxtbvkar6ScenarioGenerator(IServiceProvider sp, ILogger
 
 public class ChedWithAlvsX00WrongDocumentReferenceFormatScenarioGenerator(IServiceProvider sp, ILogger<ChedWithAlvsX00WrongDocumentReferenceFormatScenarioGenerator> logger)
     : SpecificFilesScenarioGenerator(sp, logger, "Mrn-24GBDEJTCUNJKRQAR1");
+
 public abstract class SpecificFilesScenarioGenerator(IServiceProvider sp, ILogger logger, string? sampleFolder = null) : ScenarioGenerator(logger)
 {
     private readonly IBlobService _blobService = sp.GetRequiredService<CachingBlobService>();
 
-    internal async Task<List<(string filePath, IBaseBuilder builder)>> GetBuilders(string scenarioPath)
+    internal async Task<List<(string filePath, IBaseBuilder builder)>> GetBuilders(string scenarioPath, int? scenario = null, int? item = null, DateTime? entryDate = null)
     {
         using var tokenSource = new CancellationTokenSource();
 
@@ -164,11 +165,11 @@ public abstract class SpecificFilesScenarioGenerator(IServiceProvider sp, ILogge
             .Concat(decisionList)
             .Concat(finalisationList)
             .Concat(searchGmrsList)
-            .ToList());
+            .ToList(), scenario, item, entryDate);
     }
 
     protected virtual List<(string filePath, IBaseBuilder builder)> ModifyBuilders(
-        List<(string filePath, IBaseBuilder builder)> builders)
+        List<(string filePath, IBaseBuilder builder)> builders, int? scenario = null, int? item = null, DateTime? entryDate = null)
     {
         return builders;
     }
@@ -196,7 +197,8 @@ public abstract class SpecificFilesScenarioGenerator(IServiceProvider sp, ILogge
             throw new InvalidOperationException(
                 "Either need to specify the scenarioPath in the constructor, or override the generate function.");
         }
-        var builders = GetBuilders(sampleFolder)
+
+        var builders = GetBuilders(sampleFolder, scenario, item, entryDate)
             .GetAwaiter().GetResult();
 
         Logger.LogInformation("Created {builders} Builders",

--- a/TestDataGenerator/TestDataGenerator.csproj
+++ b/TestDataGenerator/TestDataGenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+  <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
During movement sync & updates to the movement, prior to saving a Movement this calculates a "BusinessDecisionStatus" by running through a set of rules until it finds one that matches and then storing that value on the Movement.

A method in MovementAggregationService aggregates movements by this value for display in a chart in the frontend.