### PR TITLE
Initial implementation of DatasetSpecificFilesScenarioGenerator

### DIFF
--- a/TestDataGenerator/Scenarios/SpecificFiles/DatasetSpecificFilesScenarioGenerator.cs
+++ b/TestDataGenerator/Scenarios/SpecificFiles/DatasetSpecificFilesScenarioGenerator.cs
@@ -1,0 +1,41 @@
+using Btms.Types.Ipaffs;
+using Microsoft.Extensions.Logging;
+using TestDataGenerator.Helpers;
+
+namespace TestDataGenerator.Scenarios.SpecificFiles;
+
+public abstract class DatasetSpecificFilesScenarioGenerator(IServiceProvider sp, ILogger<DatasetSpecificFilesScenarioGenerator> logger, string? sampleFolder = null) : SpecificFilesScenarioGenerator(sp, logger, sampleFolder)
+{
+    protected override List<(string filePath, IBaseBuilder builder)> ModifyBuilders(List<(string filePath, IBaseBuilder builder)> builders, int? scenario = null, int? item = null, DateTime? entryDate = null)
+    {
+        if (!scenario.HasValue || !item.HasValue || !entryDate.HasValue)
+        {
+            return builders;
+        }
+
+        // There may be multiple CHEDs and MRNs in the list of builders, we want to keep those that
+        // are the same, the same, but change them to something thats unique...
+        Dictionary<string, string> referenceMap = new Dictionary<string, string>();
+
+        builders.ForEach(b =>
+            {
+                switch (b.builder)
+                {
+                    case ImportNotificationBuilder i:
+                        //Todo, need ched type...
+                        var chedReference = DataHelpers.GenerateReferenceNumber(ImportNotificationTypeEnum.Chedpp, scenario.Value, DateTime.Today, item.Value);
+
+                        break;
+                    case ClearanceRequestBuilder c:
+                        break;
+                    default:
+                        break;
+                }
+            });
+
+
+        // .WithReferenceNumber(ImportNotificationTypeEnum.Cveda, scenario, entryDate, item)
+
+        return builders;
+    }
+}


### PR DESCRIPTION
Intended to allow a Redacted MRN based session to be transformed into one that can be used in a dataset.

At present, if a redacted MRN based session generator is invoked multiple times it just generates the same message repeatedly. Effectively leading to lots of updates of the same thing.

This isn't compatible with the idea of a dataset, where we expect each invocation to generate a new set of resources.

To make this work i've started to introduce a new base class DatasetSpecificFilesScenarioGenerator which will handle ensuring everything works correctly.

Intends to find the IDs of the messages, ie CHED ref, MRN, GMR and turn them into unique references, and then update other documents that reference those IDs with the correct values so that subsequent linking etc works.

