### PR TITLE
Small change to log for GMR related linking

### DIFF
--- a/Btms.Business/Services/Linking/LoggingLinker.cs
+++ b/Btms.Business/Services/Linking/LoggingLinker.cs
@@ -27,7 +27,7 @@ public class LoggingLinker<TModel, TKModel>(
         {
             var elapsed = TimeProvider.System.GetElapsedTime(timestamp);
             logger.LogInformation("Linking {TModel} with {TKModel} took {Elapsed}ms", typeof(TModel).Name,
-                typeof(TKModel), elapsed);
+                typeof(TKModel).Name, elapsed.TotalMilliseconds);
         }
     }
 }

--- a/Btms.Business/Services/Linking/LoggingLinker.cs
+++ b/Btms.Business/Services/Linking/LoggingLinker.cs
@@ -21,13 +21,16 @@ public class LoggingLinker<TModel, TKModel>(
 
         try
         {
+            logger.LogInformation("Linking {TModel} with {TKModel}", typeof(TModel).Name, typeof(TKModel).Name);
             return await inner.Link(model, cancellationToken);
         }
         finally
         {
             var elapsed = TimeProvider.System.GetElapsedTime(timestamp);
-            logger.LogInformation("Linking {TModel} with {TKModel} took {Elapsed}ms", typeof(TModel).Name,
-                typeof(TKModel).Name, elapsed.TotalMilliseconds);
+            logger.LogInformation("Linked {TModel} with {TKModel} took {Elapsed}ms",
+                typeof(TModel).Name,
+                typeof(TKModel).Name,
+                elapsed.TotalMilliseconds);
         }
     }
 }

--- a/Btms.Business/Services/Linking/LoggingLinker.cs
+++ b/Btms.Business/Services/Linking/LoggingLinker.cs
@@ -21,7 +21,6 @@ public class LoggingLinker<TModel, TKModel>(
 
         try
         {
-            logger.LogInformation("Linking {TModel} with {TKModel}", typeof(TModel).Name, typeof(TKModel).Name);
             return await inner.Link(model, cancellationToken);
         }
         finally


### PR DESCRIPTION
As per PR title.

Originally was trying to see the log once deployed but I suspect the build deployed does not include the linking work. This PR therefore doesn't include anything new but it does tweak the log message so the full type name is not logged.