### PR TITLE
Use full namespace for type definition and add title for BTMS types

### DIFF
--- a/Btms.Backend/OpenApi/BtmsTypeSchemaFilter.cs
+++ b/Btms.Backend/OpenApi/BtmsTypeSchemaFilter.cs
@@ -1,0 +1,28 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Btms.Backend.OpenApi;
+
+/// <summary>
+/// Set the title for the type if it's from BTMS.
+/// </summary>
+public class BtmsTypeSchemaFilter : ISchemaFilter
+{
+    private readonly string _namespacePrefix;
+
+    public BtmsTypeSchemaFilter()
+    {
+        var namespacePrefix = typeof(BtmsTypeSchemaFilter).Namespace?.Split('.')[0];
+
+        _namespacePrefix = namespacePrefix ?? throw new InvalidOperationException("Namespace prefix is null");
+    }
+
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Type.Namespace?.StartsWith(_namespacePrefix) == true)
+            schema.Title = context.Type.Name;
+    }
+}

--- a/Btms.Backend/OpenApi/DocumentFilter.cs
+++ b/Btms.Backend/OpenApi/DocumentFilter.cs
@@ -16,7 +16,7 @@ public class DocumentFilter : IDocumentFilter
             path: "import-notifications",
             pathDescription: "Notification Operations",
             operationDescription: "Get Notifications",
-            referenceId: "NotificationResourceResponse",
+            referenceId: typeof(NotificationResourceResponse).FullName!,
             tag: "Notifications"
         );
 
@@ -29,7 +29,7 @@ public class DocumentFilter : IDocumentFilter
             path: "movements",
             pathDescription: "Movement Operations",
             operationDescription: "Get Movements",
-            referenceId: "MovementResourceResponse",
+            referenceId: typeof(MovementResourceResponse).FullName!,
             tag: "Movements"
         );
 
@@ -39,10 +39,10 @@ public class DocumentFilter : IDocumentFilter
         );
 
         swaggerDoc.AddPath(
-            path: "goods-movements",
+            path: "gmrs",
             pathDescription: "Goods Movement Operations",
             operationDescription: "Get Goods Movements",
-            referenceId: "GoodsMovementResourceResponse",
+            referenceId: typeof(GoodsMovementResourceResponse).FullName!,
             tag: "GoodsMovements"
         );
     }

--- a/Btms.Backend/Swagger/SwaggerGen.cs
+++ b/Btms.Backend/Swagger/SwaggerGen.cs
@@ -14,9 +14,11 @@ public static class SwaggerGen
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen(c =>
         {
+            c.CustomSchemaIds(x => x.FullName);
             c.SwaggerDoc("public-v0.1", new OpenApiInfo { Title = "BTMS Public API", Version = "v0.1" });
-            c.DocumentFilter<DocumentFilter>();
+            c.SchemaFilter<BtmsTypeSchemaFilter>();
             c.SchemaFilter<SchemaFilter>();
+            c.DocumentFilter<DocumentFilter>();
             c.UseAllOfToExtendReferenceSchemas();
             c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
         });


### PR DESCRIPTION
@craigedmunds is attempting to use the same type name for two types that are different namespaces. The Open API spec generation does not support this as it's just using the type's Name field, therefore there is a type name clash.

This PR switches to full namespace generation, whilst including the type's Name field into the title field of the Open API schema definition.

This will therefore allow the same type name in different namespaces within BTMS to feed into the Open API spec generation.