### PR TITLE
Updated Regex to allow year in 2 digit format on document reference n…

### DIFF
--- a/Btms.Business.Tests/MatchingIdentifierTests.cs
+++ b/Btms.Business.Tests/MatchingIdentifierTests.cs
@@ -29,6 +29,10 @@ public class MatchingIdentifierTests
     [InlineData("GBCHD2024.1036543v", "20241036543")]
     [InlineData("GBCVD20241036543v", "20241036543")]
     [InlineData("GBCHD20241036543v", "20241036543")]
+    [InlineData("GBCHD241036543v", "20241036543")]
+    [InlineData("GBCHD.241036543v", "20241036543")]
+    [InlineData("GBCHD24.1036543v", "20241036543")]
+    [InlineData("GBCHD.24.1036543v", "20241036543")]
     public void ReferenceNumber_FromDocumentReference_Valid(string reference, string identifier)
     {
         MatchIdentifier.FromCds(reference).Identifier.Should().Be(identifier);

--- a/Btms.Model/MatchIdentifier.cs
+++ b/Btms.Model/MatchIdentifier.cs
@@ -7,10 +7,10 @@ public static partial class RegularExpressions
     [GeneratedRegex("(CHEDD|CHEDA|CHEDP|CHEDPP)\\.?GB\\.?(20|21)\\d{2}\\.?\\d{7}[rv]?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
     internal static partial Regex IPaffsIdentifier();
 
-    [GeneratedRegex("(GBCVD|GBCHD|GBCVD|GBCHD)\\.?(20|21)\\d{2}\\.?\\d{7}[rv]?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    [GeneratedRegex("(GBCVD|GBCHD|GBCVD|GBCHD)\\.?(20|21)?\\d{2}\\.?\\d{7}[rv]?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
     internal static partial Regex DocumentReferenceWithoutCountry();
 
-    [GeneratedRegex("\\d{4}\\.?\\d{7}", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    [GeneratedRegex("\\d{2,4}\\.?\\d{7}", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
     internal static partial Regex DocumentReferenceIdentifier();
 
     public static bool IsExactMatch(this Regex regex, string input)
@@ -52,6 +52,10 @@ public struct MatchIdentifier(string identifier)
             RegularExpressions.DocumentReferenceWithoutCountry().IsExactMatch(reference))
         {
             var identifier = RegularExpressions.DocumentReferenceIdentifier().Match(reference).Value.Replace(".", "");
+            if (identifier.Length == 9)
+            {
+                identifier = $"20{identifier}";
+            }
             return new MatchIdentifier(identifier);
         }
 


### PR DESCRIPTION
This PR updates the regex to allow 2 Digit years as well as 4

So now it will accept both

GBCHD24.1036543v
GBCHD2024.1036543v