### PR TITLE
Updated decision finders along with can find decision criteria and tests

### DIFF
--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedADecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedADecisionFinderTests.cs
@@ -9,16 +9,26 @@ namespace Btms.Business.Tests.Services.Decisions.Finders;
 public class ChedADecisionFinderTests
 {
     [Theory]
-    [InlineData(null, ImportNotificationTypeEnum.Cveda, true)]
-    [InlineData(null, ImportNotificationTypeEnum.Ced, false)]
-    [InlineData(null, ImportNotificationTypeEnum.Cvedp, false)]
-    [InlineData(null, ImportNotificationTypeEnum.Chedpp, false)]
-    [InlineData(false, ImportNotificationTypeEnum.Cveda, true)]
-    [InlineData(true, ImportNotificationTypeEnum.Cveda, false)]
-    public void CanFindDecisionTest(bool? iuuCheckRequired, ImportNotificationTypeEnum? importNotificationType, bool expectedResult)
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Amend, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.InProgress, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Modify, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.PartiallyRejected, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Rejected, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.SplitConsignment, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Validated, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Replaced, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Cancelled, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false)]
+    [InlineData(false, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, true)]
+    [InlineData(true, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, false)]
+    public void CanFindDecisionTest(bool? iuuCheckRequired, ImportNotificationTypeEnum? importNotificationType, ImportNotificationStatusEnum notificationStatus, bool expectedResult)
     {
         var notification = new ImportNotification
         {
+            Status = notificationStatus,
             ImportNotificationType = importNotificationType,
             PartTwo = new PartTwo
             {

--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedDDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedDDecisionFinderTests.cs
@@ -9,16 +9,26 @@ namespace Btms.Business.Tests.Services.Decisions.Finders;
 public class ChedDDecisionFinderTests
 {
     [Theory]
-    [InlineData(null, ImportNotificationTypeEnum.Cveda, false)]
-    [InlineData(null, ImportNotificationTypeEnum.Ced, true)]
-    [InlineData(null, ImportNotificationTypeEnum.Cvedp, false)]
-    [InlineData(null, ImportNotificationTypeEnum.Chedpp, false)]
-    [InlineData(false, ImportNotificationTypeEnum.Ced, true)]
-    [InlineData(true, ImportNotificationTypeEnum.Ced, false)]
-    public void CanFindDecisionTest(bool? iuuCheckRequired, ImportNotificationTypeEnum? importNotificationType, bool expectedResult)
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Amend, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.InProgress, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Modify, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.PartiallyRejected, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Rejected, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.SplitConsignment, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Validated, true)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Replaced, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Cancelled, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false)]
+    [InlineData(null, ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false)]
+    [InlineData(false, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, true)]
+    [InlineData(true, ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, false)]
+    public void CanFindDecisionTest(bool? iuuCheckRequired, ImportNotificationTypeEnum? importNotificationType, ImportNotificationStatusEnum notificationStatus, bool expectedResult)
     {
         var notification = new ImportNotification
         {
+            Status = notificationStatus,
             ImportNotificationType = importNotificationType,
             PartTwo = new PartTwo
             {

--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedPDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedPDecisionFinderTests.cs
@@ -9,17 +9,26 @@ namespace Btms.Business.Tests.Services.Decisions.Finders;
 public class ChedPDecisionFinderTests
 {
     [Theory]
-    [InlineData(ImportNotificationTypeEnum.Cveda, false, "H222")]
-    [InlineData(ImportNotificationTypeEnum.Ced, false, "H222")]
-    [InlineData(ImportNotificationTypeEnum.Cvedp, true, "H222")]
-    [InlineData(ImportNotificationTypeEnum.Chedpp, false, "H222")]
-
-    [InlineData(ImportNotificationTypeEnum.Cvedp, true, null)]
-    [InlineData(ImportNotificationTypeEnum.Cvedp, false, "H224")]
-    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, bool expectedResult, string? checkCode)
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Amend, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.InProgress, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Modify, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.PartiallyRejected, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Rejected, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.SplitConsignment, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Validated, true, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Replaced, false, "H222")]
+    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Cancelled, false, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, false, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, false, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, true, null)]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false, "H224")]
+    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, ImportNotificationStatusEnum notificationStatus, bool expectedResult, string? checkCode)
     {
         var notification = new ImportNotification
         {
+            Status = notificationStatus,
             ImportNotificationType = importNotificationType,
         };
         var sut = new ChedPDecisionFinder();

--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedPDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedPDecisionFinderTests.cs
@@ -29,7 +29,8 @@ public class ChedPDecisionFinderTests
     {
         var notification = new ImportNotification
         {
-            Status = notificationStatus, ImportNotificationType = importNotificationType,
+            Status = notificationStatus,
+            ImportNotificationType = importNotificationType,
         };
         var sut = new ChedPDecisionFinder();
 
@@ -44,37 +45,25 @@ public class ChedPDecisionFinderTests
     [InlineData(true, DecisionDecisionEnum.AcceptableIfChanneled, null, DecisionCode.C06)]
     [InlineData(true, DecisionDecisionEnum.AcceptableForTranshipment, null, DecisionCode.E03)]
     [InlineData(true, DecisionDecisionEnum.AcceptableForSpecificWarehouse, null, DecisionCode.E03)]
-    [InlineData(true, DecisionDecisionEnum.AcceptableForTemporaryImport, null, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E96)]
+    [InlineData(true, DecisionDecisionEnum.AcceptableForTemporaryImport, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
     [InlineData(true, DecisionDecisionEnum.HorseReEntry, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
     [InlineData(true, DecisionDecisionEnum.NonAcceptable, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
-    [InlineData(true, DecisionDecisionEnum.AcceptableForPrivateImport, null, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E96)]
-    [InlineData(true, DecisionDecisionEnum.AcceptableForTransfer, null, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E96)]
+    [InlineData(true, DecisionDecisionEnum.AcceptableForPrivateImport, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
+    [InlineData(true, DecisionDecisionEnum.AcceptableForTransfer, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
     [InlineData(null, null, null, DecisionCode.X00, DecisionInternalFurtherDetail.E99)]
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Reexport, DecisionCode.N04)]
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Destruction, DecisionCode.N02)]
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Transformation, DecisionCode.N03)]
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Other, DecisionCode.N07)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.Euthanasia, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.Slaughter, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.Redispatching, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.EntryRefusal, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.QuarantineImposed, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.SpecialTreatment, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.IndustrialProcessing, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.ReDispatch, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.UseForOtherPurposes, DecisionCode.X00,
-        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.Euthanasia, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.Slaughter, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.Redispatching, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.EntryRefusal, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.QuarantineImposed, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.SpecialTreatment, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.IndustrialProcessing, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.ReDispatch, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.UseForOtherPurposes, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
     public void DecisionFinderTest(bool? consignmentAcceptable, DecisionDecisionEnum? decision,
         DecisionNotAcceptableActionEnum? notAcceptableAction, DecisionCode expectedCode,
         DecisionInternalFurtherDetail? expectedFurtherDetail = null)

--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedPDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedPDecisionFinderTests.cs
@@ -9,27 +9,27 @@ namespace Btms.Business.Tests.Services.Decisions.Finders;
 public class ChedPDecisionFinderTests
 {
     [Theory]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Amend, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.InProgress, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Modify, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.PartiallyRejected, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Rejected, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.SplitConsignment, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Validated, true, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Replaced, false, "H222")]
-    [InlineData( ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Cancelled, false, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Amend, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.InProgress, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Modify, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.PartiallyRejected, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Rejected, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.SplitConsignment, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Validated, true, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Replaced, false, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Cancelled, false, "H222")]
     [InlineData(ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, false, "H222")]
     [InlineData(ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, false, "H222")]
     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false, "H222")]
     [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, true, null)]
     [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false, "H224")]
-    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, ImportNotificationStatusEnum notificationStatus, bool expectedResult, string? checkCode)
+    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType,
+        ImportNotificationStatusEnum notificationStatus, bool expectedResult, string? checkCode)
     {
         var notification = new ImportNotification
         {
-            Status = notificationStatus,
-            ImportNotificationType = importNotificationType,
+            Status = notificationStatus, ImportNotificationType = importNotificationType,
         };
         var sut = new ChedPDecisionFinder();
 
@@ -44,30 +44,40 @@ public class ChedPDecisionFinderTests
     [InlineData(true, DecisionDecisionEnum.AcceptableIfChanneled, null, DecisionCode.C06)]
     [InlineData(true, DecisionDecisionEnum.AcceptableForTranshipment, null, DecisionCode.E03)]
     [InlineData(true, DecisionDecisionEnum.AcceptableForSpecificWarehouse, null, DecisionCode.E03)]
-
-    [InlineData(true, DecisionDecisionEnum.AcceptableForTemporaryImport, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
+    [InlineData(true, DecisionDecisionEnum.AcceptableForTemporaryImport, null, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E96)]
     [InlineData(true, DecisionDecisionEnum.HorseReEntry, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
     [InlineData(true, DecisionDecisionEnum.NonAcceptable, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
-    [InlineData(true, DecisionDecisionEnum.AcceptableForPrivateImport, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
-    [InlineData(true, DecisionDecisionEnum.AcceptableForTransfer, null, DecisionCode.X00, DecisionInternalFurtherDetail.E96)]
-
+    [InlineData(true, DecisionDecisionEnum.AcceptableForPrivateImport, null, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E96)]
+    [InlineData(true, DecisionDecisionEnum.AcceptableForTransfer, null, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E96)]
     [InlineData(null, null, null, DecisionCode.X00, DecisionInternalFurtherDetail.E99)]
-
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Reexport, DecisionCode.N04)]
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Destruction, DecisionCode.N02)]
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Transformation, DecisionCode.N03)]
     [InlineData(false, null, DecisionNotAcceptableActionEnum.Other, DecisionCode.N07)]
-
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.Euthanasia, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.Slaughter, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.Redispatching, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.EntryRefusal, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.QuarantineImposed, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.SpecialTreatment, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.IndustrialProcessing, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.ReDispatch, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    [InlineData(false, null, DecisionNotAcceptableActionEnum.UseForOtherPurposes, DecisionCode.X00, DecisionInternalFurtherDetail.E97)]
-    public void DecisionFinderTest(bool? consignmentAcceptable, DecisionDecisionEnum? decision, DecisionNotAcceptableActionEnum? notAcceptableAction, DecisionCode expectedCode, DecisionInternalFurtherDetail? expectedFurtherDetail = null)
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.Euthanasia, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.Slaughter, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.Redispatching, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.EntryRefusal, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.QuarantineImposed, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.SpecialTreatment, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.IndustrialProcessing, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.ReDispatch, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    [InlineData(false, null, DecisionNotAcceptableActionEnum.UseForOtherPurposes, DecisionCode.X00,
+        DecisionInternalFurtherDetail.E97)]
+    public void DecisionFinderTest(bool? consignmentAcceptable, DecisionDecisionEnum? decision,
+        DecisionNotAcceptableActionEnum? notAcceptableAction, DecisionCode expectedCode,
+        DecisionInternalFurtherDetail? expectedFurtherDetail = null)
     {
         var notification = new ImportNotification
         {

--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
@@ -10,17 +10,28 @@ namespace Btms.Business.Tests.Services.Decisions.Finders;
 public class ChedPpPhsiDecisionFinderTests
 {
     [Theory]
-    [InlineData(ImportNotificationTypeEnum.Cveda, false, "H219")]
-    [InlineData(ImportNotificationTypeEnum.Ced, false, "H219")]
-    [InlineData(ImportNotificationTypeEnum.Cvedp, false, "H219")]
-    [InlineData(ImportNotificationTypeEnum.Chedpp, true, "H219")]
-    [InlineData(ImportNotificationTypeEnum.Chedpp, true, "H218")]
-    [InlineData(ImportNotificationTypeEnum.Chedpp, true, "H220")]
-    [InlineData(ImportNotificationTypeEnum.Chedpp, false, null)]
-    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, bool expectedResult, string? checkCode)
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Amend, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.InProgress, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Modify, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.PartiallyRejected, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Rejected, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.SplitConsignment, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Validated, true, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Replaced, false, "H220")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Cancelled, false, "H220")]
+
+    [InlineData(ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, false, "H219")]
+    [InlineData(ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, false, "H219")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false, "H219")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, true, "H219")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, true, "H218")]
+     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false, null)]
+    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, ImportNotificationStatusEnum notificationStatus, bool expectedResult, string? checkCode)
     {
         var notification = new ImportNotification
         {
+            Status = notificationStatus,
             ImportNotificationType = importNotificationType,
         };
         var sut = new ChedPPDecisionFinder();

--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
@@ -31,7 +31,8 @@ public class ChedPpPhsiDecisionFinderTests
     {
         var notification = new ImportNotification
         {
-            Status = notificationStatus, ImportNotificationType = importNotificationType,
+            Status = notificationStatus,
+            ImportNotificationType = importNotificationType,
         };
         var sut = new ChedPPDecisionFinder();
 

--- a/Btms.Business.Tests/Services/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
@@ -20,19 +20,18 @@ public class ChedPpPhsiDecisionFinderTests
     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Validated, true, "H220")]
     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Replaced, false, "H220")]
     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Cancelled, false, "H220")]
-
     [InlineData(ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, false, "H219")]
     [InlineData(ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, false, "H219")]
     [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false, "H219")]
     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, true, "H219")]
     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, true, "H218")]
-     [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false, null)]
-    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, ImportNotificationStatusEnum notificationStatus, bool expectedResult, string? checkCode)
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false, null)]
+    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType,
+        ImportNotificationStatusEnum notificationStatus, bool expectedResult, string? checkCode)
     {
         var notification = new ImportNotification
         {
-            Status = notificationStatus,
-            ImportNotificationType = importNotificationType,
+            Status = notificationStatus, ImportNotificationType = importNotificationType,
         };
         var sut = new ChedPPDecisionFinder();
 
@@ -53,12 +52,10 @@ public class ChedPpPhsiDecisionFinderTests
     [InlineData(ImportNotificationStatusEnum.Rejected, DecisionCode.N02)]
     [InlineData(ImportNotificationStatusEnum.Replaced, DecisionCode.X00, DecisionInternalFurtherDetail.E99)]
     [InlineData(ImportNotificationStatusEnum.SplitConsignment, DecisionCode.X00, DecisionInternalFurtherDetail.E99)]
-    public void DecisionFinderTest(ImportNotificationStatusEnum status, DecisionCode expectedCode, DecisionInternalFurtherDetail? expectedFurtherDetail = null)
+    public void DecisionFinderTest(ImportNotificationStatusEnum status, DecisionCode expectedCode,
+        DecisionInternalFurtherDetail? expectedFurtherDetail = null)
     {
-        var notification = new ImportNotification
-        {
-            Status = status
-        };
+        var notification = new ImportNotification { Status = status };
         var sut = new ChedPPDecisionFinder();
 
         var result = sut.FindDecision(notification, null);

--- a/Btms.Business.Tests/Services/Decisions/Finders/IuuDecisionFinderTests.cs
+++ b/Btms.Business.Tests/Services/Decisions/Finders/IuuDecisionFinderTests.cs
@@ -9,18 +9,27 @@ namespace Btms.Business.Tests.Services.Decisions.Finders;
 public class IuuDecisionFinderTests
 {
     [Theory]
-    [InlineData(ImportNotificationTypeEnum.Cvedp, true, "H224")]
-    [InlineData(ImportNotificationTypeEnum.Cvedp, false, "H222")]
-    [InlineData(ImportNotificationTypeEnum.Cvedp, false, null)]
-
-    [InlineData(ImportNotificationTypeEnum.Cveda, false, "H224")]
-    [InlineData(ImportNotificationTypeEnum.Ced, false, "H224")]
-    [InlineData(ImportNotificationTypeEnum.Chedpp, false, "H224")]
-    [InlineData(null, false, "H224")]
-    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, bool expectedResult, string? checkCode)
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Amend, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.InProgress, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Modify, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.PartiallyRejected, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Rejected, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.SplitConsignment, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Validated, true, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Replaced, false, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Cancelled, false, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false, "H222")]
+    [InlineData(ImportNotificationTypeEnum.Cvedp, ImportNotificationStatusEnum.Submitted, false, null)]
+    [InlineData(ImportNotificationTypeEnum.Cveda, ImportNotificationStatusEnum.Submitted, false, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Ced, ImportNotificationStatusEnum.Submitted, false, "H224")]
+    [InlineData(ImportNotificationTypeEnum.Chedpp, ImportNotificationStatusEnum.Submitted, false, "H224")]
+    [InlineData(null, ImportNotificationStatusEnum.Submitted, false, "H224")]
+    public void CanFindDecisionTest(ImportNotificationTypeEnum? importNotificationType, ImportNotificationStatusEnum notificationStatus, bool expectedResult, string? checkCode)
     {
         var notification = new ImportNotification
         {
+            Status = notificationStatus,
             ImportNotificationType = importNotificationType
         };
         var sut = new IuuDecisionFinder();

--- a/Btms.Business/Services/Decisions/Finders/ChedADecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedADecisionFinder.cs
@@ -4,7 +4,7 @@ namespace Btms.Business.Services.Decisions.Finders;
 
 public class ChedADecisionFinder : IDecisionFinder
 {
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) =>
         notification.ImportNotificationType == ImportNotificationTypeEnum.Cveda &&
         notification.Status != ImportNotificationStatusEnum.Cancelled &&
         notification.Status != ImportNotificationStatusEnum.Replaced &&
@@ -22,19 +22,26 @@ public class ChedADecisionFinder : IDecisionFinder
         {
             true => notification.PartTwo?.Decision?.DecisionEnum switch
             {
-                DecisionDecisionEnum.AcceptableForTranshipment or DecisionDecisionEnum.AcceptableForTransit => new DecisionFinderResult(DecisionCode.E03, checkCode),
-                DecisionDecisionEnum.AcceptableForInternalMarket => new DecisionFinderResult(DecisionCode.C03, checkCode),
-                DecisionDecisionEnum.AcceptableForTemporaryImport => new DecisionFinderResult(DecisionCode.C05, checkCode),
+                DecisionDecisionEnum.AcceptableForTranshipment or DecisionDecisionEnum.AcceptableForTransit =>
+                    new DecisionFinderResult(DecisionCode.E03, checkCode),
+                DecisionDecisionEnum.AcceptableForInternalMarket => new DecisionFinderResult(DecisionCode.C03,
+                    checkCode),
+                DecisionDecisionEnum.AcceptableForTemporaryImport => new DecisionFinderResult(DecisionCode.C05,
+                    checkCode),
                 DecisionDecisionEnum.HorseReEntry => new DecisionFinderResult(DecisionCode.C06, checkCode),
-                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E96)
+                _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                    InternalDecisionCode: DecisionInternalFurtherDetail.E96)
             },
             false => notification.PartTwo?.Decision?.NotAcceptableAction switch
             {
-                DecisionNotAcceptableActionEnum.Euthanasia or DecisionNotAcceptableActionEnum.Slaughter => new DecisionFinderResult(DecisionCode.N02, checkCode),
+                DecisionNotAcceptableActionEnum.Euthanasia or DecisionNotAcceptableActionEnum.Slaughter =>
+                    new DecisionFinderResult(DecisionCode.N02, checkCode),
                 DecisionNotAcceptableActionEnum.Reexport => new DecisionFinderResult(DecisionCode.N04, checkCode),
-                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E97)
+                _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                    InternalDecisionCode: DecisionInternalFurtherDetail.E97)
             },
-            _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E99)
+            _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                InternalDecisionCode: DecisionInternalFurtherDetail.E99)
         };
     }
 }

--- a/Btms.Business/Services/Decisions/Finders/ChedADecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedADecisionFinder.cs
@@ -4,7 +4,11 @@ namespace Btms.Business.Services.Decisions.Finders;
 
 public class ChedADecisionFinder : IDecisionFinder
 {
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => notification.ImportNotificationType == ImportNotificationTypeEnum.Cveda && notification.PartTwo?.ControlAuthority?.IuuCheckRequired != true;
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+        notification.ImportNotificationType == ImportNotificationTypeEnum.Cveda &&
+        notification.Status != ImportNotificationStatusEnum.Cancelled &&
+        notification.Status != ImportNotificationStatusEnum.Replaced &&
+        notification.PartTwo?.ControlAuthority?.IuuCheckRequired != true;
 
     public DecisionFinderResult FindDecision(ImportNotification notification, string? checkCode)
     {

--- a/Btms.Business/Services/Decisions/Finders/ChedDDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedDDecisionFinder.cs
@@ -4,7 +4,11 @@ namespace Btms.Business.Services.Decisions.Finders;
 
 public class ChedDDecisionFinder : IDecisionFinder
 {
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => notification.ImportNotificationType == ImportNotificationTypeEnum.Ced && notification.PartTwo?.ControlAuthority?.IuuCheckRequired != true;
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+        notification.ImportNotificationType == ImportNotificationTypeEnum.Ced &&
+        notification.Status != ImportNotificationStatusEnum.Cancelled &&
+        notification.Status != ImportNotificationStatusEnum.Replaced &&
+        notification.PartTwo?.ControlAuthority?.IuuCheckRequired != true;
 
     public DecisionFinderResult FindDecision(ImportNotification notification, string? checkCode)
     {

--- a/Btms.Business/Services/Decisions/Finders/ChedDDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedDDecisionFinder.cs
@@ -4,7 +4,7 @@ namespace Btms.Business.Services.Decisions.Finders;
 
 public class ChedDDecisionFinder : IDecisionFinder
 {
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) =>
         notification.ImportNotificationType == ImportNotificationTypeEnum.Ced &&
         notification.Status != ImportNotificationStatusEnum.Cancelled &&
         notification.Status != ImportNotificationStatusEnum.Replaced &&
@@ -22,8 +22,10 @@ public class ChedDDecisionFinder : IDecisionFinder
         {
             true => notification.PartTwo?.Decision?.DecisionEnum switch
             {
-                DecisionDecisionEnum.AcceptableForInternalMarket => new DecisionFinderResult(DecisionCode.C03, checkCode),
-                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E96)
+                DecisionDecisionEnum.AcceptableForInternalMarket => new DecisionFinderResult(DecisionCode.C03,
+                    checkCode),
+                _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                    InternalDecisionCode: DecisionInternalFurtherDetail.E96)
             },
             false => notification.PartTwo?.Decision?.NotAcceptableAction switch
             {
@@ -31,9 +33,11 @@ public class ChedDDecisionFinder : IDecisionFinder
                 DecisionNotAcceptableActionEnum.Redispatching => new DecisionFinderResult(DecisionCode.N04, checkCode),
                 DecisionNotAcceptableActionEnum.Transformation => new DecisionFinderResult(DecisionCode.N03, checkCode),
                 DecisionNotAcceptableActionEnum.Other => new DecisionFinderResult(DecisionCode.N07, checkCode),
-                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E97)
+                _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                    InternalDecisionCode: DecisionInternalFurtherDetail.E97)
             },
-            _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E99)
+            _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                InternalDecisionCode: DecisionInternalFurtherDetail.E99)
         };
     }
 }

--- a/Btms.Business/Services/Decisions/Finders/ChedPDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedPDecisionFinder.cs
@@ -5,7 +5,7 @@ namespace Btms.Business.Services.Decisions.Finders;
 
 public class ChedPDecisionFinder : IDecisionFinder
 {
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) =>
         notification.ImportNotificationType == ImportNotificationTypeEnum.Cvedp &&
         notification.Status != ImportNotificationStatusEnum.Cancelled &&
         notification.Status != ImportNotificationStatusEnum.Replaced &&
@@ -18,7 +18,8 @@ public class ChedPDecisionFinder : IDecisionFinder
             return new DecisionFinderResult(code!.Value, checkCode);
         }
 
-        if (!notification.TryGetConsignmentAcceptable(out var consignmentAcceptable, out var decisionCode, out var internalDecisionCode))
+        if (!notification.TryGetConsignmentAcceptable(out var consignmentAcceptable, out var decisionCode,
+                out var internalDecisionCode))
         {
             return new DecisionFinderResult(decisionCode!.Value, checkCode, InternalDecisionCode: internalDecisionCode);
         }
@@ -29,11 +30,12 @@ public class ChedPDecisionFinder : IDecisionFinder
             {
                 DecisionDecisionEnum.AcceptableForTranshipment or DecisionDecisionEnum.AcceptableForTransit
                     or DecisionDecisionEnum.AcceptableForSpecificWarehouse =>
-
                     new DecisionFinderResult(DecisionCode.E03, checkCode),
-                DecisionDecisionEnum.AcceptableForInternalMarket => new DecisionFinderResult(DecisionCode.C03, checkCode),
+                DecisionDecisionEnum.AcceptableForInternalMarket => new DecisionFinderResult(DecisionCode.C03,
+                    checkCode),
                 DecisionDecisionEnum.AcceptableIfChanneled => new DecisionFinderResult(DecisionCode.C06, checkCode),
-                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E96)
+                _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                    InternalDecisionCode: DecisionInternalFurtherDetail.E96)
             },
             false => notification.PartTwo?.Decision?.NotAcceptableAction switch
             {
@@ -41,7 +43,8 @@ public class ChedPDecisionFinder : IDecisionFinder
                 DecisionNotAcceptableActionEnum.Reexport => new DecisionFinderResult(DecisionCode.N04, checkCode),
                 DecisionNotAcceptableActionEnum.Transformation => new DecisionFinderResult(DecisionCode.N03, checkCode),
                 DecisionNotAcceptableActionEnum.Other => new DecisionFinderResult(DecisionCode.N07, checkCode),
-                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E97)
+                _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                    InternalDecisionCode: DecisionInternalFurtherDetail.E97)
             }
         };
     }

--- a/Btms.Business/Services/Decisions/Finders/ChedPDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedPDecisionFinder.cs
@@ -5,7 +5,11 @@ namespace Btms.Business.Services.Decisions.Finders;
 
 public class ChedPDecisionFinder : IDecisionFinder
 {
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => notification.ImportNotificationType == ImportNotificationTypeEnum.Cvedp && checkCode != IuuDecisionFinder.IuuCheckCode;
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+        notification.ImportNotificationType == ImportNotificationTypeEnum.Cvedp &&
+        notification.Status != ImportNotificationStatusEnum.Cancelled &&
+        notification.Status != ImportNotificationStatusEnum.Replaced &&
+        checkCode != IuuDecisionFinder.IuuCheckCode;
 
     public DecisionFinderResult FindDecision(ImportNotification notification, string? checkCode)
     {

--- a/Btms.Business/Services/Decisions/Finders/ChedPPDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedPPDecisionFinder.cs
@@ -21,7 +21,8 @@ public class ChedPPDecisionFinder : IDecisionFinder
             ImportNotificationStatusEnum.Validated => new DecisionFinderResult(DecisionCode.C03, checkCode),
             ImportNotificationStatusEnum.Rejected => new DecisionFinderResult(DecisionCode.N02, checkCode),
             ImportNotificationStatusEnum.PartiallyRejected => new DecisionFinderResult(DecisionCode.H01, checkCode),
-            _ => new DecisionFinderResult(DecisionCode.X00, checkCode, InternalDecisionCode: DecisionInternalFurtherDetail.E99)
+            _ => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                InternalDecisionCode: DecisionInternalFurtherDetail.E99)
         };
     }
 }

--- a/Btms.Business/Services/Decisions/Finders/ChedPPDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/ChedPPDecisionFinder.cs
@@ -7,7 +7,10 @@ namespace Btms.Business.Services.Decisions.Finders;
 public class ChedPPDecisionFinder : IDecisionFinder
 {
     public bool CanFindDecision(ImportNotification notification, string? checkCode) =>
-        notification.ImportNotificationType == ImportNotificationTypeEnum.Chedpp && checkCode?.GetChedTypeFromCheckCode() == ImportNotificationTypeEnum.Chedpp;
+        notification.ImportNotificationType == ImportNotificationTypeEnum.Chedpp &&
+        notification.Status != ImportNotificationStatusEnum.Cancelled &&
+        notification.Status != ImportNotificationStatusEnum.Replaced &&
+        checkCode?.GetChedTypeFromCheckCode() == ImportNotificationTypeEnum.Chedpp;
 
     public DecisionFinderResult FindDecision(ImportNotification notification, string? checkCode)
     {

--- a/Btms.Business/Services/Decisions/Finders/IuuDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/IuuDecisionFinder.cs
@@ -6,7 +6,11 @@ public class IuuDecisionFinder : IDecisionFinder
 {
     public const string IuuCheckCode = "H224";
 
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => notification.ImportNotificationType == ImportNotificationTypeEnum.Cvedp && checkCode == IuuCheckCode;
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+        notification.ImportNotificationType == ImportNotificationTypeEnum.Cvedp &&
+        notification.Status != ImportNotificationStatusEnum.Cancelled &&
+        notification.Status != ImportNotificationStatusEnum.Replaced &&
+        checkCode == IuuCheckCode;
 
     public DecisionFinderResult FindDecision(ImportNotification notification, string? checkCode)
     {

--- a/Btms.Business/Services/Decisions/Finders/IuuDecisionFinder.cs
+++ b/Btms.Business/Services/Decisions/Finders/IuuDecisionFinder.cs
@@ -6,7 +6,7 @@ public class IuuDecisionFinder : IDecisionFinder
 {
     public const string IuuCheckCode = "H224";
 
-    public bool CanFindDecision(ImportNotification notification, string? checkCode) => 
+    public bool CanFindDecision(ImportNotification notification, string? checkCode) =>
         notification.ImportNotificationType == ImportNotificationTypeEnum.Cvedp &&
         notification.Status != ImportNotificationStatusEnum.Cancelled &&
         notification.Status != ImportNotificationStatusEnum.Replaced &&
@@ -18,13 +18,18 @@ public class IuuDecisionFinder : IDecisionFinder
         {
             true => notification.PartTwo?.ControlAuthority?.IuuOption switch
             {
-                ControlAuthorityIuuOptionEnum.Iuuok => new DecisionFinderResult(DecisionCode.C07, checkCode, "IUU Compliant"),
-                ControlAuthorityIuuOptionEnum.IUUNotCompliant => new DecisionFinderResult(DecisionCode.X00, checkCode, "IUU Not compliant - Contact Port Health Authority (imports) or Marine Management Organisation (landings)."),
-                ControlAuthorityIuuOptionEnum.Iuuna => new DecisionFinderResult(DecisionCode.C08, checkCode, "IUU Not applicable"),
+                ControlAuthorityIuuOptionEnum.Iuuok => new DecisionFinderResult(DecisionCode.C07, checkCode,
+                    "IUU Compliant"),
+                ControlAuthorityIuuOptionEnum.IUUNotCompliant => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                    "IUU Not compliant - Contact Port Health Authority (imports) or Marine Management Organisation (landings)."),
+                ControlAuthorityIuuOptionEnum.Iuuna => new DecisionFinderResult(DecisionCode.C08, checkCode,
+                    "IUU Not applicable"),
                 null => new DecisionFinderResult(DecisionCode.X00, checkCode, "IUU Awaiting decision"),
-                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, "IUU Data error", DecisionInternalFurtherDetail.E95)
+                _ => new DecisionFinderResult(DecisionCode.X00, checkCode, "IUU Data error",
+                    DecisionInternalFurtherDetail.E95)
             },
-            false => new DecisionFinderResult(DecisionCode.X00, checkCode, "IUU Data error", DecisionInternalFurtherDetail.E94)
+            false => new DecisionFinderResult(DecisionCode.X00, checkCode, "IUU Data error",
+                DecisionInternalFurtherDetail.E94)
         };
     }
 }

--- a/Btms.Business/Services/Linking/LinkResult.cs
+++ b/Btms.Business/Services/Linking/LinkResult.cs
@@ -8,4 +8,9 @@ public class LinkResult(LinkOutcome state)
     public LinkOutcome Outcome { get; set; } = state;
     public List<ImportNotification> Notifications { get; set; } = new();
     public List<Movement> Movements { get; set; } = new();
+
+    public bool IsAllNotificationsDeleted()
+    {
+        return Notifications.Count > 0 && Notifications.All(x => x.Status == ImportNotificationStatusEnum.Deleted);
+    }
 }

--- a/Btms.Business/Services/Linking/LinkingService.cs
+++ b/Btms.Business/Services/Linking/LinkingService.cs
@@ -59,6 +59,12 @@ public class LinkingService(IMongoDbContext dbContext, LinkingMetrics metrics, I
                     case MovementLinkContext movementLinkContext:
                         result = await FindMovementLinks(movementLinkContext.PersistedMovement, cancellationToken);
 
+                        if (result.Notifications.All(x => x.Status == ImportNotificationStatusEnum.Deleted))
+                        {
+                            result.Outcome = LinkOutcome.NotLinked;
+                            return result;
+                        }
+
                         if (!ShouldLinkMovement(movementLinkContext.ChangeSet))
                         {
                             logger.LinkNotAttempted(linkContext.GetType().Name, linkContext.GetIdentifiers());

--- a/Btms.Consumers/ClearanceRequestConsumer.cs
+++ b/Btms.Consumers/ClearanceRequestConsumer.cs
@@ -49,6 +49,12 @@ internal class ClearanceRequestConsumer(
                     Context.Linked();
                 }
 
+                if (linkResult.IsAllNotificationsDeleted())
+                {
+                    await dbContext.SaveChangesAsync(Context.CancellationToken);
+                    return;
+                }
+
                 if (!await validationService.PostLinking(linkContext, linkResult,
                         triggeringMovement: preProcessingResult.Record,
                         cancellationToken: Context.CancellationToken))


### PR DESCRIPTION
Updated Decision finders to change the decision making criteria to exclude cancelled and replaced notifications.

This will result in a "no finder" being found, and fall back to am X00, which is already covered by integration tests