### PR TITLE
CDMS-408 Adds blob file diagnostics to allow a file from data lake to…

### DIFF
--- a/Btms.Backend/Config/ApiOptions.cs
+++ b/Btms.Backend/Config/ApiOptions.cs
@@ -7,6 +7,7 @@ public class ApiOptions
 {
     public static readonly string SectionName = nameof(ApiOptions);
 
+    public bool EnableDiagnostics { get; set; } = default!;
     public bool EnableManagement { get; set; } = default!;
 
     public string? AnalyticsCachePolicy { get; set; } = default!;

--- a/Btms.Backend/Endpoints/DiagnosticEndpoints.cs
+++ b/Btms.Backend/Endpoints/DiagnosticEndpoints.cs
@@ -16,7 +16,7 @@ public static class DiagnosticEndpoints
 
     public static void UseDiagnosticEndpoints(this IEndpointRouteBuilder app, IOptions<ApiOptions> options)
     {
-        if (options.Value.EnableManagement)
+        if (options.Value.EnableDiagnostics)
         {
             app.MapGet(BaseRoute + "/blob", GetBlobDiagnosticAsync).AllowAnonymous();
             app.MapGet(BaseRoute + "/asb", GetAzureServiceBusDiagnosticAsync).AllowAnonymous();

--- a/Btms.Backend/Endpoints/SyncEndpoints.cs
+++ b/Btms.Backend/Endpoints/SyncEndpoints.cs
@@ -1,12 +1,21 @@
+using System.Text.Json;
 using Btms.Backend.Config;
 using Btms.Backend.Mediatr;
+using Btms.BlobService;
+using Btms.Business;
 using Btms.Business.Commands;
 using Btms.Business.Mediatr;
+using Btms.Common.Extensions;
 using Btms.Consumers.MemoryQueue;
+using Btms.SensitiveData;
 using Btms.SyncJob;
+using Btms.Types.Alvs;
+using Btms.Types.Gvms;
+using Btms.Types.Ipaffs;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using SlimMessageBus.Host;
+using Decision = Btms.Types.Alvs.Decision;
 
 namespace Btms.Backend.Endpoints;
 
@@ -18,6 +27,7 @@ public static class SyncEndpoints
     {
         if (options.Value.EnableSync)
         {
+
             app.MapGet(BaseRoute + "/import-notifications/", GetSyncNotifications).AllowAnonymous();
             app.MapPost(BaseRoute + "/import-notifications/", SyncNotifications).AllowAnonymous();
 
@@ -34,6 +44,9 @@ public static class SyncEndpoints
             app.MapPost(BaseRoute + "/finalisations/", SyncFinalisations).AllowAnonymous();
 
         }
+
+        if (options.Value.EnableDiagnostics)
+            app.MapGet(BaseRoute + "/blob/", GetBlob).AllowAnonymous();
 
         app.MapPost(BaseRoute + "/generate-download", GenerateDownload).AllowAnonymous();
         app.MapGet(BaseRoute + "/download/{id}", DownloadNotifications).AllowAnonymous();
@@ -102,6 +115,22 @@ public static class SyncEndpoints
         return Task.FromResult(queueStatsMonitor.GetAll().Any(x => x.Value.Count > 0)
              ? Results.Ok(queueStatsMonitor.GetAll())
              : Results.NoContent());
+    }
+
+    private static async Task<IResult> GetBlob(
+        [FromServices] IOptions<BusinessOptions> options,
+        [FromServices] IBlobService blobService,
+        [FromServices] ISensitiveDataSerializer sensitiveDataSerializer,
+        string path)
+    {
+        var segments = path.Split("/");
+
+        //Handles IPAFFS multiple paths per type & others which only have a single path
+        var type = DownloadCommand.BlobFolders.First(f => f.path == segments.First() || f.path.StartsWith($"{segments.First()}/")).dataType;
+        var blobContent = await blobService.GetResource(new BtmsBlobItem() { Name = $"{options.Value.DmpBlobRootFolder}/{path}" }, CancellationToken.None);
+        var redactedContent = sensitiveDataSerializer.RedactRawJson(blobContent, type);
+
+        return Results.Json(JsonDocument.Parse(redactedContent));
     }
 
     private static async Task<IResult> GetSyncNotifications(
@@ -184,5 +213,18 @@ public static class SyncEndpoints
     {
         await mediator.SendSyncJob(command);
         return Results.Accepted($"/sync/jobs/{command.JobId}", command.JobId);
+    }
+
+    private static Type ByName(string typeName)
+    {
+        return typeName switch
+        {
+            "clearance-request" => typeof(AlvsClearanceRequest),
+            "import-notification" => typeof(ImportNotification),
+            "finalisation" => typeof(Finalisation),
+            "decision" => typeof(Decision),
+            "gmr" => typeof(Gmr),
+            _ => throw new ArgumentOutOfRangeException(nameof(typeName))
+        };
     }
 }

--- a/Btms.Business/Commands/DownloadCommand.cs
+++ b/Btms.Business/Commands/DownloadCommand.cs
@@ -10,6 +10,7 @@ using Btms.Types.Alvs;
 using Btms.Types.Gvms;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Decision = Btms.Types.Alvs.Decision;
 
 namespace Btms.Business.Commands;
 
@@ -25,6 +26,18 @@ public class DownloadCommand : IRequest, ISyncJob
     public DownloadFilter? Filter { get; set; } = null;
 
     public string? RootFolder { get; set; }
+
+    public static readonly List<(string path, Type dataType)> BlobFolders =
+    [
+        ("IPAFFS/CHEDA", typeof(ImportNotification)),
+        ("IPAFFS/CHEDD", typeof(ImportNotification)),
+        ("IPAFFS/CHEDP", typeof(ImportNotification)),
+        ("IPAFFS/CHEDPP", typeof(ImportNotification)),
+        ("IPAFFS/ALVS", typeof(AlvsClearanceRequest)),
+        ("GVMSAPIRESPONSE", typeof(SearchGmrsForDeclarationIdsResponse)),
+        ("DECISIONS", typeof(Decision)),
+        ("FINALISATION", typeof(Finalisation))
+    ];
 
     internal class Handler(IBlobService blobService, ISensitiveDataSerializer sensitiveDataSerializer, IHostEnvironment env) : IRequestHandler<DownloadCommand>
     {


### PR DESCRIPTION
Allows an individual file from blob storage to be retrieved in its redacted form. Intended to help us where we need the original message, for example when diagnosing an issue like that which happened with the february data.