### PR TITLE
Fixed validation rules between document control and document status

### DIFF
--- a/Btms.Backend.Data/Mongo/MongoDbContext.cs
+++ b/Btms.Backend.Data/Mongo/MongoDbContext.cs
@@ -94,7 +94,7 @@ public class MongoDbContext : IMongoDbContext
 
     private int GetChangedRecordsCount()
     {
-        return Notifications.PendingChanges + Movements.PendingChanges + Gmrs.PendingChanges;
+        return Notifications.PendingChanges + Movements.PendingChanges + Gmrs.PendingChanges + CdsValidationErrors.PendingChanges;
     }
 
     private async Task InternalSaveChangesAsync(CancellationToken cancellation = default)

--- a/Btms.Business.Tests/MatchingIdentifierTests.cs
+++ b/Btms.Business.Tests/MatchingIdentifierTests.cs
@@ -36,6 +36,8 @@ public class MatchingIdentifierTests
     [InlineData("GBCHD.241036543v", "20241036543")]
     [InlineData("GBCHD24.1036543v", "20241036543")]
     [InlineData("GBCHD.24.1036543v", "20241036543")]
+    [InlineData("DHBGC.24.1036543v", "20241036543")]
+    [InlineData("GBGBC.2024.1036543v", "20241036543")]
     public void ReferenceNumber_FromDocumentReference_Valid(string reference, string identifier)
     {
         MatchIdentifier.FromCds(reference).Identifier.Should().Be(identifier);

--- a/Btms.Model/MatchIdentifier.cs
+++ b/Btms.Model/MatchIdentifier.cs
@@ -8,7 +8,7 @@ public static partial class RegularExpressions
     [GeneratedRegex("(CHEDD|CHEDA|CHEDP|CHEDPP)\\.?GB\\.?(20|21)\\d{2}\\.?\\d{7}[rv]?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
     internal static partial Regex IPaffsIdentifier();
 
-    [GeneratedRegex("(GBCVD|GBCHD|GBCVD|GBCHD)\\.?(20|21)?\\d{2}\\.?\\d{7}[rv]?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    [GeneratedRegex("[gbchdv]{5}\\.?(20|21)?\\d{2}\\.?\\d{7}[rv]?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
     internal static partial Regex DocumentReferenceWithoutCountry();
 
     [GeneratedRegex("(GBIUU|IUU)\\.*", RegexOptions.Compiled | RegexOptions.IgnoreCase)]

--- a/Btms.Types.Alvs.Validation.Tests/DocumentValidatorTests.cs
+++ b/Btms.Types.Alvs.Validation.Tests/DocumentValidatorTests.cs
@@ -30,13 +30,13 @@ public class DocumentValidatorTests
             Add(new Document { DocumentCode = "C633" }, new ExpectedResult(nameof(Document.DocumentCode), false));
             Add(new Document { DocumentCode = null }, new ExpectedResult(nameof(Document.DocumentCode), true));
 
-            Add(new Document { DocumentControl = "AE" }, new ExpectedResult(nameof(Document.DocumentControl), false));
-            Add(new Document { DocumentControl = "AEE" }, new ExpectedResult(nameof(Document.DocumentControl), true));
-            Add(new Document { DocumentControl = null }, new ExpectedResult(nameof(Document.DocumentControl), true));
-
-            Add(new Document { DocumentStatus = "P" }, new ExpectedResult(nameof(Document.DocumentStatus), false));
-            Add(new Document { DocumentStatus = "PP" }, new ExpectedResult(nameof(Document.DocumentStatus), true));
+            Add(new Document { DocumentStatus = "AE" }, new ExpectedResult(nameof(Document.DocumentStatus), false));
+            Add(new Document { DocumentStatus = "AEE" }, new ExpectedResult(nameof(Document.DocumentStatus), true));
             Add(new Document { DocumentStatus = null }, new ExpectedResult(nameof(Document.DocumentStatus), true));
+
+            Add(new Document { DocumentControl = "P" }, new ExpectedResult(nameof(Document.DocumentControl), false));
+            Add(new Document { DocumentControl = "PP" }, new ExpectedResult(nameof(Document.DocumentControl), true));
+            Add(new Document { DocumentControl = null }, new ExpectedResult(nameof(Document.DocumentControl), true));
         }
     }
 }

--- a/Btms.Types.Alvs.Validation/DocumentValidator.cs
+++ b/Btms.Types.Alvs.Validation/DocumentValidator.cs
@@ -9,8 +9,8 @@ public class DocumentValidator : AbstractValidator<Document>
         RuleFor(p => p.DocumentCode).Must(BeAValidDocumentCode!)
             .WithMessage(c => $"DocumentCode {c.DocumentCode} on item number {itemNumber} is invalid. Your request with correlation ID {correlationId} has been terminated.")
             .WithState(p => "ALVSVAL308");
-        RuleFor(p => p.DocumentStatus).NotEmpty().MaximumLength(1);
-        RuleFor(p => p.DocumentControl).NotEmpty().MaximumLength(2);
+        RuleFor(p => p.DocumentStatus).NotEmpty().MaximumLength(2);
+        RuleFor(p => p.DocumentControl).NotEmpty().MaximumLength(1);
     }
 
     private static List<string> documentCodes =


### PR DESCRIPTION
also updated the regex to be a bit more forgiving