### PR TITLE
Feature/cdms 277 additional tests

### DIFF
--- a/Btms.Types.Alvs.Validation.Tests/FinalisationHeaderValidatorTests.cs
+++ b/Btms.Types.Alvs.Validation.Tests/FinalisationHeaderValidatorTests.cs
@@ -32,6 +32,8 @@ public class FinalisationHeaderValidatorTests
 
             Add(CreateHeader(entryVersionNumber: 0), new ExpectedResult(nameof(FinalisationHeader.EntryVersionNumber), true));
             Add(CreateHeader(entryVersionNumber: 100), new ExpectedResult(nameof(FinalisationHeader.EntryVersionNumber), true));
+            
+            Add(CreateHeader(finalState: "10"), new ExpectedResult(nameof(FinalisationHeader.FinalState), true));
 
             Add(CreateHeader(finalState: "10"), new ExpectedResult(nameof(FinalisationHeader.FinalState), true));
 

--- a/Btms.Types.Alvs.Validation.Tests/FinalisationHeaderValidatorTests.cs
+++ b/Btms.Types.Alvs.Validation.Tests/FinalisationHeaderValidatorTests.cs
@@ -32,7 +32,7 @@ public class FinalisationHeaderValidatorTests
 
             Add(CreateHeader(entryVersionNumber: 0), new ExpectedResult(nameof(FinalisationHeader.EntryVersionNumber), true));
             Add(CreateHeader(entryVersionNumber: 100), new ExpectedResult(nameof(FinalisationHeader.EntryVersionNumber), true));
-            
+
             Add(CreateHeader(finalState: "10"), new ExpectedResult(nameof(FinalisationHeader.FinalState), true));
 
             Add(CreateHeader(finalState: "10"), new ExpectedResult(nameof(FinalisationHeader.FinalState), true));

--- a/Btms.Types.Alvs.Validation.Tests/ItemsValidatorTests.cs
+++ b/Btms.Types.Alvs.Validation.Tests/ItemsValidatorTests.cs
@@ -37,6 +37,7 @@ public class ItemsValidatorTests
 
             Add(new Items { TaricCommodityCode = "1234567899" }, new ExpectedResult(nameof(Items.TaricCommodityCode), false));
             Add(new Items { TaricCommodityCode = "0123456789" }, new ExpectedResult(nameof(Items.TaricCommodityCode), false));
+            Add(new Items { TaricCommodityCode = "01234567890" }, new ExpectedResult(nameof(Items.TaricCommodityCode), true));
             Add(new Items { TaricCommodityCode = "123456789" }, new ExpectedResult(nameof(Items.TaricCommodityCode), true));
             Add(new Items { TaricCommodityCode = null }, new ExpectedResult(nameof(Items.TaricCommodityCode), true));
 

--- a/Btms.Types.Alvs.Validation/ItemsValidator.cs
+++ b/Btms.Types.Alvs.Validation/ItemsValidator.cs
@@ -8,7 +8,7 @@ public class ItemsValidator : AbstractValidator<Items>
     {
         RuleFor(p => p.ItemNumber).NotNull().InclusiveBetween(1, 999);
         RuleFor(p => p.CustomsProcedureCode).NotEmpty().MaximumLength(7);
-        RuleFor(p => p.TaricCommodityCode).NotEmpty().Matches("\\d{10}");
+        RuleFor(p => p.TaricCommodityCode).NotEmpty().Matches("\\d").Length(10);
         RuleFor(p => p.GoodsDescription).NotEmpty().MaximumLength(280);
 
         RuleFor(p => p.ConsigneeId).NotEmpty().MaximumLength(18);


### PR DESCRIPTION
updated the regex and added a test because the TaricCommodityCode field is meant to be 10 chars long and can start with 0.