### PR TITLE
CDMS-633: Remove open-telemetry integration

### DIFF
--- a/Btms.Backend/Btms.Backend.csproj
+++ b/Btms.Backend/Btms.Backend.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.11.1" />
     <PackageReference Include="idunno.Authentication.Basic" Version="2.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.10.0-beta.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
@@ -34,12 +33,7 @@
 
     <PackageReference Include="JsonApiDotNetCore" Version="5.6.0" />
     <PackageReference Include="JsonApiDotNetCore.MongoDb" Version="5.6.0" />
-
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
+    
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 

--- a/Btms.Backend/Program.cs
+++ b/Btms.Backend/Program.cs
@@ -26,9 +26,6 @@ using JsonApiDotNetCore.Repositories;
 using JsonApiDotNetCore.Serialization.Response;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
-using OpenTelemetry;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
 using Serilog;
 using Serilog.Core;
 using System.Diagnostics.CodeAnalysis;
@@ -125,30 +122,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
     builder.Services.AddMsalHttpProxyClient(Proxy.ConfigurePrimaryHttpMessageHandler);
 
     builder.Services.AddValidatorsFromAssemblyContaining<Program>();
-
-    // This uses grafana for metrics and tracing and works with the local docker compose setup as well as in CDP
-
-    builder.Services.AddOpenTelemetry()
-        .WithMetrics(metrics =>
-        {
-            metrics.AddRuntimeInstrumentation()
-                .AddMeter(
-                    "Microsoft.AspNetCore.Hosting",
-                    "Microsoft.AspNetCore.Server.Kestrel",
-                    "System.Net.Http",
-                    MetricNames.MeterName,
-                    AnalyticsMetricNames.MeterName)
-                .AddPrometheusExporter();
-        })
-        .WithTracing(tracing =>
-        {
-            tracing.AddAspNetCoreInstrumentation()
-                .AddHttpClientInstrumentation()
-                .AddSource(MetricNames.MeterName)
-                .AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources");
-        })
-        .UseOtlpExporter();
-
+    
     static void ConfigureJsonApiOptions(JsonApiOptions options)
     {
         options.Namespace = "api";
@@ -186,12 +160,7 @@ static Logger ConfigureLogging(WebApplicationBuilder builder)
     var logBuilder = new LoggerConfiguration()
         .ReadFrom.Configuration(builder.Configuration)
         .Enrich.With<LogLevelMapper>()
-        .Enrich.WithProperty("service.version", Environment.GetEnvironmentVariable("SERVICE_VERSION"))
-        .WriteTo.OpenTelemetry(options =>
-        {
-            options.LogsEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
-            options.ResourceAttributes.Add("service.name", MetricNames.MeterName);
-        });
+        .Enrich.WithProperty("service.version", Environment.GetEnvironmentVariable("SERVICE_VERSION"));
 
     ////if (traceIdHeader != null)
     ////{
@@ -282,11 +251,6 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
     app.UseManagementEndpoints(apiOptions);
     app.UseDiagnosticEndpoints(apiOptions);
     app.UseAnalyticsEndpoints(apiOptions);
-
-    if (builder.Environment.IsDevelopment())
-    {
-        app.UseOpenTelemetryPrometheusScrapingEndpoint();
-    }
 
     return app;
 }

--- a/Btms.Backend/Program.cs
+++ b/Btms.Backend/Program.cs
@@ -122,7 +122,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
     builder.Services.AddMsalHttpProxyClient(Proxy.ConfigurePrimaryHttpMessageHandler);
 
     builder.Services.AddValidatorsFromAssemblyContaining<Program>();
-    
+
     static void ConfigureJsonApiOptions(JsonApiOptions options)
     {
         options.Namespace = "api";

--- a/Btms.Backend/appsettings.Development.json
+++ b/Btms.Backend/appsettings.Development.json
@@ -1,5 +1,4 @@
 {
-  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://grafana.localtest.me:9000",
   "AWS_EMF_ENABLED": false,
   "Mongo": {
     "DatabaseUri": "mongodb://127.0.0.1:29017?retryWrites=false",

--- a/Btms.Backend/appsettings.json
+++ b/Btms.Backend/appsettings.json
@@ -1,6 +1,4 @@
 {
-  "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
-  "OTEL_SERVICE_NAME": "Btms.Backend",
   "AWS_EMF_NAMESPACE": "BtmsBackend",
   "TraceHeader": "x-cdp-request-id",
   "Mongo": {


### PR DESCRIPTION
This PR removes the open-telemetry integration which is no longer needed.

[CDMS-633](https://eaflood.atlassian.net/browse/CDMS-633)

[CDMS-633]: https://eaflood.atlassian.net/browse/CDMS-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ